### PR TITLE
fix(input): improve input APIs, add unit tests, enforce coverage metrics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.formatOnPaste": true,
+    // Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.
+    "editor.formatOnSave": true,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "editor.formatOnPaste": true,
-    // Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.
-    "editor.formatOnSave": true,
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-};
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: -10
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "cp -r ./build/* . && rm -rf ./build && rm -rf ./src && rm jest.config.js && rm tsconfig.json",
     "postpublish": "git clean -fd",
     "package:lib": "npm run build && cp ./package.json build && cp README.md build && cd build && npm version \"5.0.0\" && npm pack",
-    "test": "jest",
+    "test": "jest --coverage",
     "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
     "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'"
   },

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -1,1 +1,7 @@
-export * from './readAndValidateInput'
+export {
+  getString,
+  getNumber,
+  getChoice,
+  getConfirmation,
+  getUrl
+} from './readAndValidateInput'

--- a/src/input/readAndValidateInput.spec.ts
+++ b/src/input/readAndValidateInput.spec.ts
@@ -3,70 +3,311 @@ import {
   getConfirmation,
   getNumber,
   getString,
-  getUrl
+  getUrl,
+  InputType,
+  readAndValidateInput
 } from './readAndValidateInput'
 import prompts from 'prompts'
+import { confirmationValidator } from './validators'
 jest.mock('prompts')
 
-describe('readAndValidateInput', () => {
+const defaultErrorMessage = 'Invalid input.'
+
+describe('getString', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should call prompts to get string values', async (done) => {
-    const fieldName = 'name'
     const message = 'Enter your name: '
     const validator = (value: string) => !!value
-    spyOn(prompts, 'prompt')
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ text: 'abc' }))
 
-    await getString(fieldName, message, validator)
+    await getString(message, validator)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
+    expect(prompts.prompt).toHaveBeenCalledWith({
+      type: 'text',
+      name: 'text',
+      initial: '',
+      message,
+      validate: validator,
+      choices: []
+    })
     done()
+  })
+
+  it('should throw an error when a string value is null', async (done) => {
+    const message = 'Enter your name: '
+    const validator = (value: string) => !!value
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ text: null }))
+
+    await expect(getString(message, validator)).rejects.toThrowError(
+      defaultErrorMessage
+    )
+    done()
+  })
+
+  it('should throw an error when a string value is undefined', async (done) => {
+    const message = 'Enter your name: '
+    const validator = (value: string) => !!value
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ text: undefined }))
+
+    await expect(getString(message, validator)).rejects.toThrowError(
+      defaultErrorMessage
+    )
+    done()
+  })
+})
+
+describe('getNumber', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should call prompts to get number values', async (done) => {
-    const fieldName = 'number'
     const message = 'Enter a number: '
+    const defaultValue = 0
     const validator = (value: number) => !!value
-    spyOn(prompts, 'prompt')
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ number: 123 }))
 
-    await getNumber(fieldName, message, validator, 0)
+    await getNumber(message, validator, defaultValue)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
+    expect(prompts.prompt).toHaveBeenCalledWith({
+      type: 'number',
+      name: 'number',
+      initial: defaultValue,
+      message,
+      validate: validator,
+      choices: []
+    })
     done()
+  })
+
+  it('should throw an error when a number value is a string', async (done) => {
+    const message = 'Enter a number: '
+    const defaultValue = 0
+    const validator = (value: number) => !!value
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ number: 'test' }))
+
+    await expect(
+      getNumber(message, validator, defaultValue)
+    ).rejects.toThrowError(defaultErrorMessage)
+    done()
+  })
+
+  it('should throw an error when a number value is null', async (done) => {
+    const message = 'Enter a number: '
+    const defaultValue = 0
+    const validator = (value: number) => !!value
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ number: null }))
+
+    await expect(
+      getNumber(message, validator, defaultValue)
+    ).rejects.toThrowError(defaultErrorMessage)
+    done()
+  })
+
+  it('should throw an error when a number value is undefined', async (done) => {
+    const message = 'Enter a number: '
+    const defaultValue = 0
+    const validator = (value: number) => !!value
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ number: undefined }))
+
+    await expect(
+      getNumber(message, validator, defaultValue)
+    ).rejects.toThrowError(defaultErrorMessage)
+    done()
+  })
+})
+
+describe('getUrl', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should call prompts to get URL values', async (done) => {
-    const fieldName = 'url'
     const message = 'Enter a URL: '
     const errorMessage = 'URL is invalid.'
-    spyOn(prompts, 'prompt')
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ url: '' }))
 
-    await getUrl(fieldName, message, errorMessage)
+    await getUrl(message, errorMessage)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
+    expect(prompts.prompt).toHaveBeenCalledWith({
+      type: 'text',
+      name: 'url',
+      initial: '',
+      message,
+      validate: expect.anything(),
+      choices: []
+    })
     done()
+  })
+
+  it('should throw an error when the value is null', async (done) => {
+    const message = 'Enter a URL: '
+    const errorMessage = 'URL is invalid.'
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ url: null }))
+
+    await expect(getUrl(message, errorMessage)).rejects.toThrowError(
+      errorMessage
+    )
+    done()
+  })
+
+  it('should throw an error when the value is undefined', async (done) => {
+    const message = 'Enter a URL: '
+    const errorMessage = 'URL is invalid.'
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ url: undefined }))
+
+    await expect(getUrl(message, errorMessage)).rejects.toThrowError(
+      errorMessage
+    )
+    done()
+  })
+})
+
+describe('getConfirmation', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should call prompts to get a confirmation', async (done) => {
-    const fieldName = 'confirm'
     const message = 'Are you sure? '
-    spyOn(prompts, 'prompt')
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ confirm: true }))
 
-    await getConfirmation(fieldName, message, false)
+    await getConfirmation(message, false)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
+    expect(prompts.prompt).toHaveBeenCalledWith({
+      type: 'confirm',
+      name: 'confirm',
+      initial: false,
+      message,
+      validate: confirmationValidator,
+      choices: []
+    })
     done()
   })
 
-  it('should call prompts to get a selection', async (done) => {
-    const fieldName = 'select'
-    const message = 'Choose: '
-    spyOn(prompts, 'prompt')
+  it('should throw an error when the value is non-boolean', async (done) => {
+    const message = 'Are you sure? '
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ confirm: 'test' }))
 
-    await getChoice(fieldName, message, (v) => !!v, 0, [
-      { title: 'Option 1' },
-      { title: 'Option 2' }
-    ])
+    await expect(getConfirmation(message, false)).rejects.toThrowError(
+      defaultErrorMessage
+    )
+    done()
+  })
+})
+
+describe('getChoice', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call prompts to get a selection', async (done) => {
+    const message = 'Choose: '
+    const errorMessage = 'Invalid choice.'
+    const choices = [{ title: 'Option 1' }, { title: 'Option 2' }]
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ choice: 1 }))
+
+    await getChoice(message, errorMessage, choices)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
+    expect(prompts.prompt).toHaveBeenCalledWith({
+      type: 'select',
+      name: 'choice',
+      initial: 0,
+      message,
+      validate: expect.anything(),
+      choices
+    })
     done()
+  })
+
+  it('should throw an error with a non-number choice', async (done) => {
+    const message = 'Choose: '
+    const errorMessage = 'Invalid choice.'
+    const choices = [{ title: 'Option 1' }, { title: 'Option 2' }]
+    jest
+      .spyOn(prompts, 'prompt')
+      .mockImplementation(() => Promise.resolve({ choice: 'abc' }))
+
+    await expect(
+      getChoice(message, errorMessage, choices)
+    ).rejects.toThrowError(errorMessage)
+    done()
+  })
+})
+
+describe('readAndValidateInput', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should throw an error when the input type is invalid', async () => {
+    jest.spyOn(prompts, 'prompt')
+
+    await expect(
+      readAndValidateInput(
+        'garbage' as InputType,
+        'choice',
+        'Choose',
+        (v) => !!v
+      )
+    ).rejects.toThrowError(
+      'Invalid input type. Valid input types are `text`, `number`, `url`, `confirm` and `select`'
+    )
+  })
+
+  it('should throw an error when the input type is select and there are no choices provided', async () => {
+    jest.spyOn(prompts, 'prompt')
+
+    await expect(
+      readAndValidateInput('select', 'choice', 'Choose', (v) => !!v)
+    ).rejects.toThrowError(
+      'A set of choices is required to be supplied with the `select` input type.'
+    )
+  })
+
+  it('should throw an error when the input type is not select and there are choices provided', async () => {
+    jest.spyOn(prompts, 'prompt')
+
+    await expect(
+      readAndValidateInput('number', 'choice', 'Choose', (v) => !!v, 1, [
+        { title: 'Test' }
+      ])
+    ).rejects.toThrowError(
+      'Choices are only supported with the `select` input type.'
+    )
   })
 })

--- a/src/input/validators.spec.ts
+++ b/src/input/validators.spec.ts
@@ -1,0 +1,102 @@
+import {
+  choiceValidator,
+  confirmationValidator,
+  urlValidator
+} from './validators'
+
+const errorMessage = 'Invalid input.'
+
+describe('urlValidator', () => {
+  it('should return true with an HTTP URL', () => {
+    const url = 'http://google.com'
+
+    expect(urlValidator(url, errorMessage)).toEqual(true)
+  })
+
+  it('should return true with an HTTPS URL', () => {
+    const url = 'https://google.com'
+
+    expect(urlValidator(url, errorMessage)).toEqual(true)
+  })
+
+  it('should return true when the URL is blank', () => {
+    const url = ''
+
+    expect(urlValidator(url, errorMessage)).toEqual(true)
+  })
+
+  it('should return an error message when the URL isinvalid', () => {
+    const url = 'htpps://google.com'
+
+    expect(urlValidator(url, errorMessage)).toEqual(errorMessage)
+  })
+
+  it('should return an error message when the URL is null', () => {
+    const url = null
+
+    expect(urlValidator((url as unknown) as string, errorMessage)).toEqual(
+      errorMessage
+    )
+  })
+
+  it('should return an error message when the URL is undefined', () => {
+    const url = undefined
+
+    expect(urlValidator((url as unknown) as string, errorMessage)).toEqual(
+      errorMessage
+    )
+  })
+})
+
+describe('confirmationValidator', () => {
+  it('should return true when the value is true', () => {
+    expect(confirmationValidator(true)).toEqual(true)
+  })
+
+  it('should return true when the value is false', () => {
+    expect(confirmationValidator(false)).toEqual(true)
+  })
+
+  it('should return false when the value is null', () => {
+    expect(confirmationValidator(null)).toEqual(false)
+  })
+
+  it('should return false when the value is undefined', () => {
+    expect(confirmationValidator(undefined)).toEqual(false)
+  })
+
+  it('should return false when the value is a string', () => {
+    expect(confirmationValidator('test')).toEqual(false)
+  })
+
+  it('should return false when the value is a number', () => {
+    expect(confirmationValidator(123)).toEqual(false)
+  })
+})
+
+describe('choiceValidator', () => {
+  it('should return true when the choice is valid', () => {
+    const choice = 1
+    const numberOfChoices = 10
+
+    expect(choiceValidator(choice, numberOfChoices, errorMessage)).toEqual(true)
+  })
+
+  it('should return the error message when the choice is less than 1', () => {
+    const choice = 0
+    const numberOfChoices = 10
+
+    expect(choiceValidator(choice, numberOfChoices, errorMessage)).toEqual(
+      errorMessage
+    )
+  })
+
+  it('should return the error message when the choice is greater than the number of choices', () => {
+    const choice = 2
+    const numberOfChoices = 1
+
+    expect(choiceValidator(choice, numberOfChoices, errorMessage)).toEqual(
+      errorMessage
+    )
+  })
+})

--- a/src/input/validators.ts
+++ b/src/input/validators.ts
@@ -1,0 +1,16 @@
+import validUrl from 'valid-url'
+
+export const urlValidator = (value: string, errorMessage: string) =>
+  !!validUrl.isHttpUri(value) ||
+  !!validUrl.isHttpsUri(value) ||
+  value === '' ||
+  errorMessage
+
+export const confirmationValidator = (value: any) =>
+  value === true || value === false
+
+export const choiceValidator = (
+  value: number,
+  numberOfChoices: number,
+  errorMessage: string
+) => (value > 0 && value <= numberOfChoices) || errorMessage

--- a/src/logger/Logger.spec.ts
+++ b/src/logger/Logger.spec.ts
@@ -40,6 +40,15 @@ describe('Logger', () => {
     expect(consola.error).toHaveBeenCalledTimes(1)
   })
 
+  it('should not log errors when the log level is Off', () => {
+    const logger = new Logger(LogLevel.Off)
+    spyOn(consola, 'error')
+
+    logger.error('This is an error.')
+
+    expect(consola.error).not.toHaveBeenCalled()
+  })
+
   it('should log info messages when the log level is Info', () => {
     const logger = new Logger(LogLevel.Info)
     spyOn(consola, 'info')
@@ -47,5 +56,59 @@ describe('Logger', () => {
     logger.info('This is info.')
 
     expect(consola.info).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not log info messages when the log level is Error', () => {
+    const logger = new Logger(LogLevel.Error)
+    spyOn(consola, 'info')
+
+    logger.info('This is info.')
+
+    expect(consola.info).not.toHaveBeenCalled()
+  })
+
+  it('should log debug messages when the log level is Debug', () => {
+    const logger = new Logger(LogLevel.Debug)
+    spyOn(consola, 'debug')
+
+    logger.debug('This is debug.')
+
+    expect(consola.debug).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not log debug messages when the log level is Error', () => {
+    const logger = new Logger(LogLevel.Error)
+    spyOn(consola, 'debug')
+
+    logger.debug('This is debug.')
+
+    expect(consola.debug).not.toHaveBeenCalled()
+  })
+
+  it('should log success messages when the log level is Debug', () => {
+    const logger = new Logger(LogLevel.Debug)
+    spyOn(consola, 'success')
+
+    logger.success('This is success.')
+
+    expect(consola.success).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not log success messages when the log level is Error', () => {
+    const logger = new Logger(LogLevel.Error)
+    spyOn(consola, 'success')
+
+    logger.success('This is success.')
+
+    expect(consola.success).not.toHaveBeenCalled()
+  })
+
+  it('should log a message regardless of log level', () => {
+    const logger = new Logger(LogLevel.Off)
+    spyOn(consola, 'log')
+
+    logger.log('This is a log.')
+
+    expect(consola.log).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/logger/isLowerThanOrEqualTo.spec.ts
+++ b/src/logger/isLowerThanOrEqualTo.spec.ts
@@ -29,6 +29,15 @@ describe('isLowerThanOrEqualTo', () => {
     expect(result).toBeTruthy()
   })
 
+  it('should return true when the current level is lower than the level passed in', () => {
+    const currentLevel = LogLevel.Info
+    const level = LogLevel.Error
+
+    const result = isLowerThanOrEqualTo(currentLevel, level)
+
+    expect(result).toBeTruthy()
+  })
+
   it('should return true when the current level is equal to the level passed in', () => {
     const currentLevel = LogLevel.Warn
     const level = LogLevel.Warn


### PR DESCRIPTION
## Issue

https://github.com/sasjs/utils/issues/8

## Intent

Improve input functions - remove the need to pass in `fieldName`, and do some additional validation before returning the value.

## Implementation

* Added `validators.ts` which has common validation functions.
* Removed `fieldName` argument from all functions.
* Validated the returned value before resolving.
* Added tests for all scenarios.
* Enforced code coverage metrics.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`). - I will refactor the implementation in `sasjs-cli` in a subsequent PR.
