### PR TITLE
feat(target): create new model for target

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
       lines: 80,
       statements: -10
     }
-  }
+  },
+  collectCoverageFrom: ['src/**/{!(index),}.ts']
 }

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,1 +1,2 @@
-export * from './Logger'
+export * from './logger'
+export * from './logLevel'

--- a/src/logger/isLowerThanOrEqualTo.spec.ts
+++ b/src/logger/isLowerThanOrEqualTo.spec.ts
@@ -1,5 +1,5 @@
 import { isLowerThanOrEqualTo } from './isLowerThanOrEqualTo'
-import { LogLevel } from './Logger'
+import { LogLevel } from './logLevel'
 
 describe('isLowerThanOrEqualTo', () => {
   it('should return false when the current level is OFF', () => {

--- a/src/logger/isLowerThanOrEqualTo.ts
+++ b/src/logger/isLowerThanOrEqualTo.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from './Logger'
+import { LogLevel } from './logLevel'
 
 export const isLowerThanOrEqualTo = (
   currentLevel: LogLevel,

--- a/src/logger/logLevel.ts
+++ b/src/logger/logLevel.ts
@@ -1,0 +1,7 @@
+export enum LogLevel {
+  Debug = 'Debug',
+  Info = 'Info',
+  Warn = 'Warn',
+  Error = 'Error',
+  Off = 'Off'
+}

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,14 +1,7 @@
 import consola from 'consola'
 import { isLowerThanOrEqualTo } from './isLowerThanOrEqualTo'
 import { isNullOrUndefined } from './isNullOrUndefined'
-
-export enum LogLevel {
-  Debug = 'Debug',
-  Info = 'Info',
-  Warn = 'Warn',
-  Error = 'Error',
-  Off = 'Off'
-}
+import { LogLevel } from './logLevel'
 
 export class Logger {
   constructor(logLevel?: LogLevel) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -22,3 +22,10 @@ export interface StreamConfig {
   streamWebFolder: string
   webSourcePath: string
 }
+
+export interface AuthConfig {
+  access_token: string
+  refresh_token: string
+  client: string
+  secret: string
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,24 @@
+export interface Config {
+  macroVars: { [key: string]: string }
+  initProgram: string
+  termProgram: string
+}
+export interface BuildConfig extends Config {
+  buildOutputFileName: string
+}
+export interface DeployConfig {
+  deployServicePack: boolean
+  deployScripts: string[]
+}
+export interface ServiceConfig extends Config {
+  serviceFolders: string[]
+}
+export interface JobConfig extends Config {
+  jobFolders: string[]
+}
+export interface StreamConfig {
+  assetPaths: string[]
+  streamWeb: boolean
+  streamWebFolder: string
+  webSourcePath: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export * from './sasAuthResponse'
 export * from './serverType'
-export * from './target'
+export { Target } from './target'

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -44,17 +44,20 @@ describe('Target', () => {
     ).toThrowError('Error parsing target: Invalid app location')
   })
 
-  it('should throw an error with an invalid build config', () => {
-    expect(
-      () =>
-        new Target({
-          name: 'test',
-          serverUrl: '',
-          serverType: ServerType.Sas9,
-          appLoc: '/test',
-          buildConfig: {}
-        })
-    ).toThrowError('Error parsing target: Invalid build config')
+  it('should set defaults with an empty build config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      buildConfig: {}
+    })
+
+    expect(target.buildConfig).toBeTruthy()
+    expect(target.buildConfig.buildOutputFileName).toEqual('test.sas')
+    expect(target.buildConfig.initProgram).toEqual('')
+    expect(target.buildConfig.termProgram).toEqual('')
+    expect(target.buildConfig.macroVars).toEqual({})
   })
 
   it('should create an instance when the JSON is valid', () => {
@@ -62,7 +65,8 @@ describe('Target', () => {
       name: 'test',
       serverUrl: '',
       serverType: ServerType.Sas9,
-      appLoc: '/test'
+      appLoc: '/test',
+      contextName: 'Test Context'
     })
 
     expect(target).toBeTruthy()
@@ -71,6 +75,7 @@ describe('Target', () => {
     expect(target.serverUrl).toEqual('')
     expect(target.serverType).toEqual(ServerType.Sas9)
     expect(target.appLoc).toEqual('/test')
+    expect(target.contextName).toEqual('Test Context')
   })
 
   it('should create an instance with build config when the JSON is valid', () => {
@@ -209,5 +214,86 @@ describe('Target', () => {
     expect(target).toBeTruthy()
     expect(target instanceof Target).toEqual(true)
     expect(target.programFolders).toEqual(['foo'])
+  })
+
+  it('should create an instance with the minimum set of attributes', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.SasViya)
+    expect(target.appLoc).toEqual('/test')
+  })
+
+  it('should throw an error when trying to access an undefined build config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(() => target.buildConfig).toThrowError(
+      'Build config has not been defined for build target test.'
+    )
+  })
+
+  it('should throw an error when trying to access an undefined deploy config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(() => target.deployConfig).toThrowError(
+      'Deploy config has not been defined for build target test.'
+    )
+  })
+
+  it('should throw an error when trying to access an undefined job config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(() => target.jobConfig).toThrowError(
+      'Job config has not been defined for build target test.'
+    )
+  })
+
+  it('should throw an error when trying to access an undefined service config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(() => target.serviceConfig).toThrowError(
+      'Service config has not been defined for build target test.'
+    )
+  })
+
+  it('should throw an error when trying to access an undefined stream config', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test'
+    })
+
+    expect(() => target.streamConfig).toThrowError(
+      'Stream config has not been defined for build target test.'
+    )
   })
 })

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -1,0 +1,213 @@
+import { ServerType } from './serverType'
+import { Target } from './target'
+
+describe('Target', () => {
+  it('should throw an error with null JSON', () => {
+    expect(() => new Target(null)).toThrowError(
+      'Error parsing target: Invalid target: Input JSON is null or undefined.'
+    )
+  })
+
+  it('should throw an error with undefined JSON', () => {
+    expect(() => new Target(undefined)).toThrowError(
+      'Error parsing target: Invalid target: Input JSON is null or undefined.'
+    )
+  })
+
+  it('should throw an error with an invalid name', () => {
+    expect(() => new Target({ name: '' })).toThrowError(
+      'Error parsing target: Invalid target name'
+    )
+  })
+
+  it('should throw an error with an invalid server URL', () => {
+    expect(
+      () => new Target({ name: 'test', serverUrl: 'gibberish' })
+    ).toThrowError('Error parsing target: Invalid server URL')
+  })
+
+  it('should throw an error with an invalid server type', () => {
+    expect(
+      () => new Target({ name: 'test', serverUrl: '', serverType: 'garbage' })
+    ).toThrowError('Error parsing target: Invalid server type')
+  })
+
+  it('should throw an error with an invalid appLoc', () => {
+    expect(
+      () =>
+        new Target({
+          name: 'test',
+          serverUrl: '',
+          serverType: ServerType.Sas9,
+          appLoc: ''
+        })
+    ).toThrowError('Error parsing target: Invalid app location')
+  })
+
+  it('should throw an error with an invalid build config', () => {
+    expect(
+      () =>
+        new Target({
+          name: 'test',
+          serverUrl: '',
+          serverType: ServerType.Sas9,
+          appLoc: '/test',
+          buildConfig: {}
+        })
+    ).toThrowError('Error parsing target: Invalid build config')
+  })
+
+  it('should create an instance when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test'
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+  })
+
+  it('should create an instance with build config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      buildConfig: {
+        buildOutputFileName: 'test',
+        initProgram: 'init',
+        termProgram: 'term'
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.buildConfig).toBeTruthy()
+    expect(target.buildConfig.buildOutputFileName).toEqual('test')
+    expect(target.buildConfig.initProgram).toEqual('init')
+    expect(target.buildConfig.termProgram).toEqual('term')
+    expect(target.buildConfig.macroVars).toEqual({})
+  })
+
+  it('should create an instance with deploy config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      deployConfig: {
+        deployServicePack: true,
+        deployScripts: ['foo', 'bar']
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.deployConfig).toBeTruthy()
+    expect(target.deployConfig.deployServicePack).toEqual(true)
+    expect(target.deployConfig.deployScripts).toEqual(['foo', 'bar'])
+  })
+
+  it('should create an instance with service config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      serviceConfig: {
+        serviceFolders: [],
+        initProgram: 'init',
+        termProgram: 'term'
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.serviceConfig).toBeTruthy()
+    expect(target.serviceConfig.serviceFolders).toEqual([])
+    expect(target.serviceConfig.initProgram).toEqual('init')
+    expect(target.serviceConfig.termProgram).toEqual('term')
+  })
+
+  it('should create an instance with job config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      jobConfig: {
+        jobFolders: [],
+        initProgram: 'init',
+        termProgram: 'term'
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.jobConfig).toBeTruthy()
+    expect(target.jobConfig.jobFolders).toEqual([])
+    expect(target.jobConfig.initProgram).toEqual('init')
+    expect(target.jobConfig.termProgram).toEqual('term')
+  })
+
+  it('should create an instance with stream config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      streamConfig: {
+        assetPaths: [],
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: '.'
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.streamConfig).toBeTruthy()
+    expect(target.streamConfig.assetPaths).toEqual([])
+    expect(target.streamConfig.streamWeb).toEqual(true)
+    expect(target.streamConfig.streamWebFolder).toEqual('.')
+    expect(target.streamConfig.webSourcePath).toEqual('.')
+  })
+
+  it('should create an instance with macro folders when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      macroFolders: ['foo']
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.macroFolders).toEqual(['foo'])
+  })
+
+  it('should create an instance with program folders when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      programFolders: ['foo']
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.programFolders).toEqual(['foo'])
+  })
+})

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -142,6 +142,8 @@ describe('Target', () => {
     expect(target.serviceConfig.serviceFolders).toEqual([])
     expect(target.serviceConfig.initProgram).toEqual('init')
     expect(target.serviceConfig.termProgram).toEqual('term')
+    expect(target.serverName).toEqual('SASApp')
+    expect(target.repositoryName).toEqual('Foundation')
   })
 
   it('should create an instance with job config when the JSON is valid', () => {
@@ -230,6 +232,30 @@ describe('Target', () => {
     expect(target.serverUrl).toEqual('')
     expect(target.serverType).toEqual(ServerType.SasViya)
     expect(target.appLoc).toEqual('/test')
+  })
+
+  it('should create an instance with the auth config when available', () => {
+    const authConfig = {
+      access_token: 'T35T',
+      refresh_token: 'R3FR35H',
+      client: 'CL13NT',
+      secret: '53CR3T'
+    }
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test',
+      authConfig
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.SasViya)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.authConfig).toEqual(authConfig)
   })
 
   it('should throw an error when trying to access an undefined build config', () => {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -1,4 +1,5 @@
 import {
+  AuthConfig,
   BuildConfig,
   DeployConfig,
   ServiceConfig,
@@ -18,7 +19,8 @@ import {
   validateStreamConfig,
   validateContextName,
   validateServerName,
-  validateRepositoryName
+  validateRepositoryName,
+  validateAuthConfig
 } from './targetValidators'
 
 interface TargetInterface {
@@ -29,6 +31,7 @@ interface TargetInterface {
   serverName?: string
   repositoryName?: string
   appLoc: string
+  authConfig?: AuthConfig
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
   serviceConfig?: ServiceConfig
@@ -58,6 +61,11 @@ export class Target implements TargetInterface {
     return this._appLoc
   }
   private _appLoc
+
+  get authConfig(): AuthConfig | undefined {
+    return this._authConfig
+  }
+  private _authConfig: AuthConfig | undefined
 
   get buildConfig(): BuildConfig {
     if (!this._buildConfig) {
@@ -153,6 +161,10 @@ export class Target implements TargetInterface {
         json.repositoryName,
         this._serverType
       )
+
+      if (json.authConfig) {
+        this._authConfig = validateAuthConfig(json.authConfig)
+      }
 
       if (json.buildConfig) {
         this._buildConfig = validateBuildConfig(json.buildConfig, this._name)

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -22,6 +22,7 @@ interface TargetInterface {
   name: string
   serverUrl: string
   serverType: ServerType
+  contextName?: string
   appLoc: string
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
@@ -36,12 +37,12 @@ export class Target implements TargetInterface {
   get name(): string {
     return this._name
   }
-  private _name = ''
+  private _name
 
   get serverUrl(): string {
     return this._serverUrl
   }
-  private _serverUrl = ''
+  private _serverUrl
 
   get serverType(): ServerType {
     return this._serverType
@@ -51,55 +52,57 @@ export class Target implements TargetInterface {
   get appLoc(): string {
     return this._appLoc
   }
-  private _appLoc = ''
+  private _appLoc
 
   get buildConfig(): BuildConfig {
+    if (!this._buildConfig) {
+      throw new Error(
+        `Build config has not been defined for build target ${this._name}.`
+      )
+    }
     return this._buildConfig
   }
-  private _buildConfig: BuildConfig = {
-    macroVars: {},
-    initProgram: '',
-    termProgram: '',
-    buildOutputFileName: ''
-  }
+  private _buildConfig: BuildConfig | undefined
 
   get deployConfig(): DeployConfig {
+    if (!this._deployConfig) {
+      throw new Error(
+        `Deploy config has not been defined for build target ${this._name}.`
+      )
+    }
     return this._deployConfig
   }
-  private _deployConfig: DeployConfig = {
-    deployServicePack: false,
-    deployScripts: []
-  }
+  private _deployConfig: DeployConfig | undefined
 
   get serviceConfig(): ServiceConfig {
+    if (!this._serviceConfig) {
+      throw new Error(
+        `Service config has not been defined for build target ${this._name}.`
+      )
+    }
     return this._serviceConfig
   }
-  private _serviceConfig: ServiceConfig = {
-    macroVars: {},
-    initProgram: '',
-    termProgram: '',
-    serviceFolders: []
-  }
+  private _serviceConfig: ServiceConfig | undefined
 
   get jobConfig(): JobConfig {
+    if (!this._jobConfig) {
+      throw new Error(
+        `Job config has not been defined for build target ${this._name}.`
+      )
+    }
     return this._jobConfig
   }
-  private _jobConfig: JobConfig = {
-    macroVars: {},
-    initProgram: '',
-    termProgram: '',
-    jobFolders: []
-  }
+  private _jobConfig: JobConfig | undefined
 
   get streamConfig(): StreamConfig {
+    if (!this._streamConfig) {
+      throw new Error(
+        `Stream config has not been defined for build target ${this._name}.`
+      )
+    }
     return this._streamConfig
   }
-  private _streamConfig: StreamConfig = {
-    assetPaths: [],
-    streamWeb: false,
-    streamWebFolder: '',
-    webSourcePath: ''
-  }
+  private _streamConfig: StreamConfig | undefined
 
   get macroFolders(): string[] {
     return this._macroFolders
@@ -111,6 +114,11 @@ export class Target implements TargetInterface {
   }
   private _programFolders: string[] = []
 
+  get contextName(): string {
+    return this._contextName
+  }
+  private _contextName: string
+
   constructor(json: any) {
     try {
       if (!json) {
@@ -121,9 +129,10 @@ export class Target implements TargetInterface {
       this._serverUrl = validateServerUrl(json.serverUrl)
       this._serverType = validateServerType(json.serverType)
       this._appLoc = validateAppLoc(json.appLoc)
+      this._contextName = json.contextName
 
       if (json.buildConfig) {
-        this._buildConfig = validateBuildConfig(json.buildConfig)
+        this._buildConfig = validateBuildConfig(json.buildConfig, this._name)
       }
 
       if (json.deployConfig) {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -1,46 +1,156 @@
+import {
+  BuildConfig,
+  DeployConfig,
+  ServiceConfig,
+  JobConfig,
+  StreamConfig
+} from './config'
 import { ServerType } from './serverType'
+import {
+  validateTargetName,
+  validateServerUrl,
+  validateServerType,
+  validateAppLoc,
+  validateBuildConfig,
+  validateDeployConfig,
+  validateServiceConfig,
+  validateJobConfig,
+  validateStreamConfig
+} from './targetValidators'
 
-export interface Config {
-  macroVars: { [key: string]: string }
-  initProgram: string
-  termProgram: string
-}
-
-export interface BuildConfig extends Config {
-  buildOutputFileName: string
-}
-
-export interface DeployConfig {
-  deployServicePack: boolean
-  deployScripts: string[]
-}
-
-export interface ServiceConfig extends Config {
-  serviceFolders: string[]
-}
-
-export interface JobConfig extends Config {
-  jobFolders: string[]
-}
-
-export interface StreamConfig {
-  assetPaths: string[]
-  streamWeb: boolean
-  streamWebFolder: string
-  webSourcePath: string
-}
-
-export interface Target {
+interface TargetInterface {
   name: string
   serverUrl: string
   serverType: ServerType
   appLoc: string
-  buildConfig: BuildConfig
-  deployConfig: DeployConfig
-  //   deployVars: { [key: string]: string }
-  serviceConfig: ServiceConfig
-  jobConfig: JobConfig
-  streamConfig: StreamConfig
+  buildConfig?: BuildConfig
+  deployConfig?: DeployConfig
+  serviceConfig?: ServiceConfig
+  jobConfig?: JobConfig
+  streamConfig?: StreamConfig
   macroFolders: string[]
   programFolders: string[]
+}
+
+export class Target implements TargetInterface {
+  get name(): string {
+    return this._name
+  }
+  private _name = ''
+
+  get serverUrl(): string {
+    return this._serverUrl
+  }
+  private _serverUrl = ''
+
+  get serverType(): ServerType {
+    return this._serverType
+  }
+  private _serverType = ServerType.SasViya
+
+  get appLoc(): string {
+    return this._appLoc
+  }
+  private _appLoc = ''
+
+  get buildConfig(): BuildConfig {
+    return this._buildConfig
+  }
+  private _buildConfig: BuildConfig = {
+    macroVars: {},
+    initProgram: '',
+    termProgram: '',
+    buildOutputFileName: ''
+  }
+
+  get deployConfig(): DeployConfig {
+    return this._deployConfig
+  }
+  private _deployConfig: DeployConfig = {
+    deployServicePack: false,
+    deployScripts: []
+  }
+
+  get serviceConfig(): ServiceConfig {
+    return this._serviceConfig
+  }
+  private _serviceConfig: ServiceConfig = {
+    macroVars: {},
+    initProgram: '',
+    termProgram: '',
+    serviceFolders: []
+  }
+
+  get jobConfig(): JobConfig {
+    return this._jobConfig
+  }
+  private _jobConfig: JobConfig = {
+    macroVars: {},
+    initProgram: '',
+    termProgram: '',
+    jobFolders: []
+  }
+
+  get streamConfig(): StreamConfig {
+    return this._streamConfig
+  }
+  private _streamConfig: StreamConfig = {
+    assetPaths: [],
+    streamWeb: false,
+    streamWebFolder: '',
+    webSourcePath: ''
+  }
+
+  get macroFolders(): string[] {
+    return this._macroFolders
+  }
+  private _macroFolders: string[] = []
+
+  get programFolders(): string[] {
+    return this._programFolders
+  }
+  private _programFolders: string[] = []
+
+  constructor(json: any) {
+    try {
+      if (!json) {
+        throw new Error('Invalid target: Input JSON is null or undefined.')
+      }
+
+      this._name = validateTargetName(json.name)
+      this._serverUrl = validateServerUrl(json.serverUrl)
+      this._serverType = validateServerType(json.serverType)
+      this._appLoc = validateAppLoc(json.appLoc)
+
+      if (json.buildConfig) {
+        this._buildConfig = validateBuildConfig(json.buildConfig)
+      }
+
+      if (json.deployConfig) {
+        this._deployConfig = validateDeployConfig(json.deployConfig)
+      }
+
+      if (json.serviceConfig) {
+        this._serviceConfig = validateServiceConfig(json.serviceConfig)
+      }
+
+      if (json.jobConfig) {
+        this._jobConfig = validateJobConfig(json.jobConfig)
+      }
+
+      if (json.streamConfig) {
+        this._streamConfig = validateStreamConfig(json.streamConfig)
+      }
+
+      if (json.macroFolders && json.macroFolders.length) {
+        this._macroFolders = json.macroFolders
+      }
+
+      if (json.programFolders && json.programFolders.length) {
+        this._programFolders = json.programFolders
+      }
+    } catch (e) {
+      throw new Error(`Error parsing target: ${(e as Error).message}`)
+    }
+  }
 }

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -1,25 +1,46 @@
 import { ServerType } from './serverType'
 
+export interface Config {
+  macroVars: { [key: string]: string }
+  initProgram: string
+  termProgram: string
+}
+
+export interface BuildConfig extends Config {
+  buildOutputFileName: string
+}
+
+export interface DeployConfig {
+  deployServicePack: boolean
+  deployScripts: string[]
+}
+
+export interface ServiceConfig extends Config {
+  serviceFolders: string[]
+}
+
+export interface JobConfig extends Config {
+  jobFolders: string[]
+}
+
+export interface StreamConfig {
+  assetPaths: string[]
+  streamWeb: boolean
+  streamWebFolder: string
+  webSourcePath: string
+}
+
 export interface Target {
   name: string
   serverUrl: string
   serverType: ServerType
   appLoc: string
-  buildOutputFileName: string
-  deployServicePack: boolean
-  tgtBuildInit: string
-  tgtBuildTerm: string
-  tgtBuildVars: { [key: string]: string }
-  tgtDeployVars: { [key: string]: string }
-  tgtServiceVars: { [key: string]: string }
-  tgtDeployScripts: string[]
-  tgtMacros: string[]
-  tgtServices: string[]
-  tgtServiceInit: string
-  jobs: string[]
-  assetPaths: string[]
-  streamWeb: boolean
-  streamWebFolder: string
-  webSourcePath: string
+  buildConfig: BuildConfig
+  deployConfig: DeployConfig
+  //   deployVars: { [key: string]: string }
+  serviceConfig: ServiceConfig
+  jobConfig: JobConfig
+  streamConfig: StreamConfig
+  macroFolders: string[]
   programFolders: string[]
 }

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -15,7 +15,10 @@ import {
   validateDeployConfig,
   validateServiceConfig,
   validateJobConfig,
-  validateStreamConfig
+  validateStreamConfig,
+  validateContextName,
+  validateServerName,
+  validateRepositoryName
 } from './targetValidators'
 
 interface TargetInterface {
@@ -23,6 +26,8 @@ interface TargetInterface {
   serverUrl: string
   serverType: ServerType
   contextName?: string
+  serverName?: string
+  repositoryName?: string
   appLoc: string
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
@@ -119,6 +124,16 @@ export class Target implements TargetInterface {
   }
   private _contextName: string
 
+  get serverName(): string {
+    return this._serverName
+  }
+  private _serverName: string
+
+  get repositoryName(): string {
+    return this._repositoryName
+  }
+  private _repositoryName: string
+
   constructor(json: any) {
     try {
       if (!json) {
@@ -129,7 +144,15 @@ export class Target implements TargetInterface {
       this._serverUrl = validateServerUrl(json.serverUrl)
       this._serverType = validateServerType(json.serverType)
       this._appLoc = validateAppLoc(json.appLoc)
-      this._contextName = json.contextName
+      this._contextName = validateContextName(
+        json.contextName,
+        this._serverType
+      )
+      this._serverName = validateServerName(json.serverName, this._serverType)
+      this._repositoryName = validateRepositoryName(
+        json.repositoryName,
+        this._serverType
+      )
 
       if (json.buildConfig) {
         this._buildConfig = validateBuildConfig(json.buildConfig, this._name)

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -149,121 +149,75 @@ describe('validateServerUrl', () => {
 describe('validateBuildConfig', () => {
   it('should throw an error when input JSON is null', () => {
     expect(() =>
-      validateBuildConfig((null as unknown) as BuildConfig)
+      validateBuildConfig((null as unknown) as BuildConfig, 'test')
     ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateBuildConfig((undefined as unknown) as BuildConfig)
+      validateBuildConfig((undefined as unknown) as BuildConfig, 'test')
     ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
   })
 
-  it('should throw an error when build output filename is empty', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: ''
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
+  it('should use the default when build output filename is undefined', () => {
+    expect(validateBuildConfig(({} as unknown) as BuildConfig, 'test')).toEqual(
+      {
+        buildOutputFileName: 'test.sas',
+        initProgram: '',
+        termProgram: '',
+        macroVars: {}
+      }
     )
   })
 
-  it('should throw an error when build output filename is null', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: null
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
-    )
+  it('should set the init program to the empty string if null', () => {
+    expect(
+      validateBuildConfig(
+        ({
+          buildOutputFileName: 'test.sas',
+          initProgram: null
+        } as unknown) as BuildConfig,
+        'test'
+      )
+    ).toEqual({
+      buildOutputFileName: 'test.sas',
+      initProgram: '',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
-  it('should throw an error when build output filename is undefined', () => {
-    expect(() =>
-      validateBuildConfig(({} as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is empty', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: ''
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is null', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: null
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is undefined', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test'
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is empty', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: 'test',
-        termProgram: ''
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is null', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: 'test',
-        termProgram: null
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is undefined', () => {
-    expect(() =>
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: 'test'
-      } as unknown) as BuildConfig)
-    ).toThrowError(
-      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
-    )
+  it('should set the term program to the empty string if null', () => {
+    expect(
+      validateBuildConfig(
+        ({
+          buildOutputFileName: 'output.sas',
+          initProgram: 'test',
+          termProgram: ''
+        } as unknown) as BuildConfig,
+        'test'
+      )
+    ).toEqual({
+      buildOutputFileName: 'output.sas',
+      initProgram: 'test',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
   it('should return the build config when valid', () => {
     expect(
-      validateBuildConfig({
-        buildOutputFileName: 'test',
-        initProgram: 'test',
-        termProgram: 'test',
-        macroVars: { foo: 'bar' }
-      })
+      validateBuildConfig(
+        {
+          buildOutputFileName: 'output.sas',
+          initProgram: 'test',
+          termProgram: 'test',
+          macroVars: { foo: 'bar' }
+        },
+        'test'
+      )
     ).toEqual({
-      buildOutputFileName: 'test',
+      buildOutputFileName: 'output.sas',
       initProgram: 'test',
       termProgram: 'test',
       macroVars: { foo: 'bar' }
@@ -272,11 +226,14 @@ describe('validateBuildConfig', () => {
 
   it('should initialise the macro vars if not present', () => {
     expect(
-      validateBuildConfig(({
-        buildOutputFileName: 'test',
-        initProgram: 'test',
-        termProgram: 'test'
-      } as unknown) as BuildConfig)
+      validateBuildConfig(
+        ({
+          buildOutputFileName: 'test',
+          initProgram: 'test',
+          termProgram: 'test'
+        } as unknown) as BuildConfig,
+        'test'
+      )
     ).toEqual({
       buildOutputFileName: 'test',
       initProgram: 'test',
@@ -347,82 +304,33 @@ describe('validateServiceConfig', () => {
     ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
   })
 
-  it('should throw an error when init program is empty', () => {
-    expect(() =>
-      validateServiceConfig({
-        serviceFolders: [],
-        initProgram: '',
-        termProgram: 'term',
-        macroVars: {}
-      })
-    ).toThrowError(
-      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is null', () => {
-    expect(() =>
+  it('should set the init program to the empty string if null', () => {
+    expect(
       validateServiceConfig(({
         serviceFolders: [],
-        initProgram: null,
-        termProgram: 'term',
-        macroVars: {}
+        initProgram: null
       } as unknown) as ServiceConfig)
-    ).toThrowError(
-      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
-    )
+    ).toEqual({
+      serviceFolders: [],
+      initProgram: '',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
-  it('should throw an error when init program is undefined', () => {
-    expect(() =>
+  it('should set the term program to the empty string if null', () => {
+    expect(
       validateServiceConfig(({
         serviceFolders: [],
-        initProgram: undefined,
-        termProgram: 'term',
-        macroVars: {}
+        initProgram: 'test',
+        termProgram: ''
       } as unknown) as ServiceConfig)
-    ).toThrowError(
-      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is empty', () => {
-    expect(() =>
-      validateServiceConfig({
-        serviceFolders: [],
-        initProgram: 'init',
-        termProgram: '',
-        macroVars: {}
-      })
-    ).toThrowError(
-      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is null', () => {
-    expect(() =>
-      validateServiceConfig(({
-        serviceFolders: [],
-        initProgram: 'init',
-        termProgram: null,
-        macroVars: {}
-      } as unknown) as ServiceConfig)
-    ).toThrowError(
-      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is undefined', () => {
-    expect(() =>
-      validateServiceConfig(({
-        serviceFolders: [],
-        initProgram: 'init',
-        termProgram: undefined,
-        macroVars: {}
-      } as unknown) as ServiceConfig)
-    ).toThrowError(
-      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
-    )
+    ).toEqual({
+      serviceFolders: [],
+      initProgram: 'test',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
   it('should return the service config when valid', () => {
@@ -469,82 +377,33 @@ describe('validateJobConfig', () => {
     ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
   })
 
-  it('should throw an error when init program is empty', () => {
-    expect(() =>
-      validateJobConfig({
-        jobFolders: [],
-        initProgram: '',
-        termProgram: 'term',
-        macroVars: {}
-      })
-    ).toThrowError(
-      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is null', () => {
-    expect(() =>
-      validateJobConfig(({
-        serviceFolders: [],
-        initProgram: null,
-        termProgram: 'term',
-        macroVars: {}
-      } as unknown) as JobConfig)
-    ).toThrowError(
-      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when init program is undefined', () => {
-    expect(() =>
-      validateJobConfig(({
-        serviceFolders: [],
-        initProgram: undefined,
-        termProgram: 'term',
-        macroVars: {}
-      } as unknown) as JobConfig)
-    ).toThrowError(
-      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is empty', () => {
-    expect(() =>
-      validateJobConfig({
-        jobFolders: [],
-        initProgram: 'init',
-        termProgram: '',
-        macroVars: {}
-      })
-    ).toThrowError(
-      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
-    )
-  })
-
-  it('should throw an error when term program is null', () => {
-    expect(() =>
+  it('should set the init program to the empty string if null', () => {
+    expect(
       validateJobConfig(({
         jobFolders: [],
-        initProgram: 'init',
-        termProgram: null,
-        macroVars: {}
+        initProgram: null
       } as unknown) as JobConfig)
-    ).toThrowError(
-      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
-    )
+    ).toEqual({
+      jobFolders: [],
+      initProgram: '',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
-  it('should throw an error when term program is undefined', () => {
-    expect(() =>
+  it('should set the term program to the empty string if null', () => {
+    expect(
       validateJobConfig(({
         jobFolders: [],
-        initProgram: 'init',
-        termProgram: undefined,
-        macroVars: {}
+        initProgram: 'test',
+        termProgram: ''
       } as unknown) as JobConfig)
-    ).toThrowError(
-      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
-    )
+    ).toEqual({
+      jobFolders: [],
+      initProgram: 'test',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
   it('should return the service config when valid', () => {

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -1,0 +1,679 @@
+import {
+  BuildConfig,
+  DeployConfig,
+  JobConfig,
+  ServiceConfig,
+  StreamConfig
+} from './config'
+import { ServerType } from './serverType'
+import {
+  validateTargetName,
+  validateServerType,
+  validateAppLoc,
+  validateServerUrl,
+  validateBuildConfig,
+  validateDeployConfig,
+  validateServiceConfig,
+  validateJobConfig,
+  validateStreamConfig
+} from './targetValidators'
+
+describe('validateTargetName', () => {
+  it('should throw an error with null target name', () => {
+    expect(() => validateTargetName((null as unknown) as string)).toThrowError(
+      'Invalid target name: `name` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error with undefined target name', () => {
+    expect(() =>
+      validateTargetName((undefined as unknown) as string)
+    ).toThrowError(
+      'Invalid target name: `name` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error with a target name that contains spaces', () => {
+    expect(() => validateTargetName('target name')).toThrowError(
+      'Invalid target name: `name` cannot include spaces.'
+    )
+  })
+
+  it('should throw an error with a target name that contains non-alphanumeric characters', () => {
+    expect(() => validateTargetName('targetname#€£')).toThrowError(
+      'Invalid target name: `name` can only contain alphanumeric characters.'
+    )
+  })
+
+  it('should return target name when valid', () => {
+    expect(validateTargetName('validTargetName')).toEqual('validTargetName')
+  })
+})
+
+describe('validateServerType', () => {
+  it('should throw an error when server type is null', () => {
+    expect(() =>
+      validateServerType((null as unknown) as ServerType)
+    ).toThrowError(
+      'Invalid server type: `serverType` cannot be null or undefined.'
+    )
+  })
+
+  it('should throw an error when server type is undefined', () => {
+    expect(() =>
+      validateServerType((undefined as unknown) as ServerType)
+    ).toThrowError(
+      'Invalid server type: `serverType` cannot be null or undefined.'
+    )
+  })
+
+  it('should throw an error when server type is not SAS9 or SASViya', () => {
+    expect(() =>
+      validateServerType(('garbage' as unknown) as ServerType)
+    ).toThrowError(
+      `Invalid server type: Supported values for  \`serverType\` are ${ServerType.SasViya} and ${ServerType.Sas9}.`
+    )
+  })
+
+  it('should return the server type when it is SAS9', () => {
+    expect(validateServerType(ServerType.Sas9)).toEqual(ServerType.Sas9)
+  })
+
+  it('should return the server type when it is SASViya', () => {
+    expect(validateServerType(ServerType.SasViya)).toEqual(ServerType.SasViya)
+  })
+})
+
+describe('validateAppLoc', () => {
+  it('should throw an error when appLoc is null', () => {
+    expect(() => validateAppLoc((null as unknown) as string)).toThrowError(
+      'Invalid app location: `appLoc` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when appLoc is undefined', () => {
+    expect(() => validateAppLoc((undefined as unknown) as string)).toThrowError(
+      'Invalid app location: `appLoc` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when appLoc is empty', () => {
+    expect(() => validateAppLoc('')).toThrowError(
+      'Invalid app location: `appLoc` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when appLoc does not start with a slash', () => {
+    expect(() => validateAppLoc('path/to/folder')).toThrowError(
+      'Invalid app location: `appLoc` must start with a `/`.'
+    )
+  })
+
+  it('should return the appLoc when valid', () => {
+    expect(validateAppLoc('/path/to/folder')).toEqual('/path/to/folder')
+  })
+})
+
+describe('validateServerUrl', () => {
+  it('should throw an error when server URL is null', () => {
+    expect(() => validateServerUrl((null as unknown) as string)).toThrowError(
+      'Invalid server URL: `serverUrl` cannot be null or undefined.'
+    )
+  })
+
+  it('should throw an error when server URL is undefined', () => {
+    expect(() =>
+      validateServerUrl((undefined as unknown) as string)
+    ).toThrowError(
+      'Invalid server URL: `serverUrl` cannot be null or undefined.'
+    )
+  })
+
+  it('should throw an error when server URL is not a valid URL', () => {
+    expect(() => validateServerUrl('my-domain-name')).toThrowError(
+      'Invalid server URL: `serverUrl` should either be an empty string or a valid URL of the form http(s)://your-server.com(:port).'
+    )
+  })
+
+  it('should return the serverUrl when empty', () => {
+    expect(validateServerUrl('')).toEqual('')
+  })
+
+  it('should return the serverUrl when valid', () => {
+    expect(validateServerUrl('http://my-server.com:1234')).toEqual(
+      'http://my-server.com:1234'
+    )
+  })
+})
+
+describe('validateBuildConfig', () => {
+  it('should throw an error when input JSON is null', () => {
+    expect(() =>
+      validateBuildConfig((null as unknown) as BuildConfig)
+    ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when input JSON is undefined', () => {
+    expect(() =>
+      validateBuildConfig((undefined as unknown) as BuildConfig)
+    ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when build output filename is empty', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: ''
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when build output filename is null', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: null
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when build output filename is undefined', () => {
+    expect(() =>
+      validateBuildConfig(({} as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is empty', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: ''
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is null', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: null
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is undefined', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test'
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is empty', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: 'test',
+        termProgram: ''
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is null', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: 'test',
+        termProgram: null
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is undefined', () => {
+    expect(() =>
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: 'test'
+      } as unknown) as BuildConfig)
+    ).toThrowError(
+      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should return the build config when valid', () => {
+    expect(
+      validateBuildConfig({
+        buildOutputFileName: 'test',
+        initProgram: 'test',
+        termProgram: 'test',
+        macroVars: { foo: 'bar' }
+      })
+    ).toEqual({
+      buildOutputFileName: 'test',
+      initProgram: 'test',
+      termProgram: 'test',
+      macroVars: { foo: 'bar' }
+    })
+  })
+
+  it('should initialise the macro vars if not present', () => {
+    expect(
+      validateBuildConfig(({
+        buildOutputFileName: 'test',
+        initProgram: 'test',
+        termProgram: 'test'
+      } as unknown) as BuildConfig)
+    ).toEqual({
+      buildOutputFileName: 'test',
+      initProgram: 'test',
+      termProgram: 'test',
+      macroVars: {}
+    })
+  })
+})
+
+describe('validateDeployConfig', () => {
+  it('should throw an error when deployConfig is null', () => {
+    expect(() =>
+      validateDeployConfig((null as unknown) as DeployConfig)
+    ).toThrowError('Invalid deploy config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when deployConfig is undefined', () => {
+    expect(() =>
+      validateDeployConfig((undefined as unknown) as DeployConfig)
+    ).toThrowError('Invalid deploy config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when deployServicePack is non-boolean', () => {
+    expect(() =>
+      validateDeployConfig(({
+        deployServicePack: 'test',
+        deployScripts: []
+      } as unknown) as DeployConfig)
+    ).toThrowError(
+      'Invalid deploy config: `deployServicePack` cannot be a non-boolean value.'
+    )
+  })
+
+  it('should return the deploy config when valid', () => {
+    expect(
+      validateDeployConfig({
+        deployServicePack: true,
+        deployScripts: []
+      })
+    ).toEqual({
+      deployServicePack: true,
+      deployScripts: []
+    })
+  })
+
+  it('should initialise deployScripts when not initialised', () => {
+    expect(
+      validateDeployConfig(({
+        deployServicePack: true
+      } as unknown) as DeployConfig)
+    ).toEqual({
+      deployServicePack: true,
+      deployScripts: []
+    })
+  })
+})
+
+describe('validateServiceConfig', () => {
+  it('should throw an error when input JSON is null', () => {
+    expect(() =>
+      validateServiceConfig((null as unknown) as ServiceConfig)
+    ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when input JSON is undefined', () => {
+    expect(() =>
+      validateServiceConfig((undefined as unknown) as ServiceConfig)
+    ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when init program is empty', () => {
+    expect(() =>
+      validateServiceConfig({
+        serviceFolders: [],
+        initProgram: '',
+        termProgram: 'term',
+        macroVars: {}
+      })
+    ).toThrowError(
+      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is null', () => {
+    expect(() =>
+      validateServiceConfig(({
+        serviceFolders: [],
+        initProgram: null,
+        termProgram: 'term',
+        macroVars: {}
+      } as unknown) as ServiceConfig)
+    ).toThrowError(
+      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is undefined', () => {
+    expect(() =>
+      validateServiceConfig(({
+        serviceFolders: [],
+        initProgram: undefined,
+        termProgram: 'term',
+        macroVars: {}
+      } as unknown) as ServiceConfig)
+    ).toThrowError(
+      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is empty', () => {
+    expect(() =>
+      validateServiceConfig({
+        serviceFolders: [],
+        initProgram: 'init',
+        termProgram: '',
+        macroVars: {}
+      })
+    ).toThrowError(
+      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is null', () => {
+    expect(() =>
+      validateServiceConfig(({
+        serviceFolders: [],
+        initProgram: 'init',
+        termProgram: null,
+        macroVars: {}
+      } as unknown) as ServiceConfig)
+    ).toThrowError(
+      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is undefined', () => {
+    expect(() =>
+      validateServiceConfig(({
+        serviceFolders: [],
+        initProgram: 'init',
+        termProgram: undefined,
+        macroVars: {}
+      } as unknown) as ServiceConfig)
+    ).toThrowError(
+      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should return the service config when valid', () => {
+    expect(
+      validateServiceConfig({
+        serviceFolders: [],
+        initProgram: 'init',
+        termProgram: 'term',
+        macroVars: {}
+      })
+    ).toEqual({
+      serviceFolders: [],
+      initProgram: 'init',
+      termProgram: 'term',
+      macroVars: {}
+    })
+  })
+
+  it('should initialise the macro vars if not present', () => {
+    expect(
+      validateServiceConfig(({
+        initProgram: 'init',
+        termProgram: 'term'
+      } as unknown) as ServiceConfig)
+    ).toEqual({
+      serviceFolders: [],
+      initProgram: 'init',
+      termProgram: 'term',
+      macroVars: {}
+    })
+  })
+})
+
+describe('validateJobConfig', () => {
+  it('should throw an error when input JSON is null', () => {
+    expect(() =>
+      validateJobConfig((null as unknown) as JobConfig)
+    ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when input JSON is undefined', () => {
+    expect(() =>
+      validateJobConfig((undefined as unknown) as JobConfig)
+    ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when init program is empty', () => {
+    expect(() =>
+      validateJobConfig({
+        jobFolders: [],
+        initProgram: '',
+        termProgram: 'term',
+        macroVars: {}
+      })
+    ).toThrowError(
+      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is null', () => {
+    expect(() =>
+      validateJobConfig(({
+        serviceFolders: [],
+        initProgram: null,
+        termProgram: 'term',
+        macroVars: {}
+      } as unknown) as JobConfig)
+    ).toThrowError(
+      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when init program is undefined', () => {
+    expect(() =>
+      validateJobConfig(({
+        serviceFolders: [],
+        initProgram: undefined,
+        termProgram: 'term',
+        macroVars: {}
+      } as unknown) as JobConfig)
+    ).toThrowError(
+      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is empty', () => {
+    expect(() =>
+      validateJobConfig({
+        jobFolders: [],
+        initProgram: 'init',
+        termProgram: '',
+        macroVars: {}
+      })
+    ).toThrowError(
+      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is null', () => {
+    expect(() =>
+      validateJobConfig(({
+        jobFolders: [],
+        initProgram: 'init',
+        termProgram: null,
+        macroVars: {}
+      } as unknown) as JobConfig)
+    ).toThrowError(
+      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when term program is undefined', () => {
+    expect(() =>
+      validateJobConfig(({
+        jobFolders: [],
+        initProgram: 'init',
+        termProgram: undefined,
+        macroVars: {}
+      } as unknown) as JobConfig)
+    ).toThrowError(
+      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should return the service config when valid', () => {
+    expect(
+      validateJobConfig({
+        jobFolders: [],
+        initProgram: 'init',
+        termProgram: 'term',
+        macroVars: {}
+      })
+    ).toEqual({
+      jobFolders: [],
+      initProgram: 'init',
+      termProgram: 'term',
+      macroVars: {}
+    })
+  })
+
+  it('should initialise the macro vars if not present', () => {
+    expect(
+      validateJobConfig(({
+        initProgram: 'init',
+        termProgram: 'term'
+      } as unknown) as JobConfig)
+    ).toEqual({
+      jobFolders: [],
+      initProgram: 'init',
+      termProgram: 'term',
+      macroVars: {}
+    })
+  })
+})
+
+describe('validateStreamConfig', () => {
+  it('should throw an error when input JSON is null', () => {
+    expect(() =>
+      validateStreamConfig((null as unknown) as StreamConfig)
+    ).toThrowError('Invalid stream config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when input JSON is undefined', () => {
+    expect(() =>
+      validateStreamConfig((undefined as unknown) as StreamConfig)
+    ).toThrowError('Invalid stream config: JSON cannot be null or undefined.')
+  })
+
+  it('should throw an error when streamWeb is a non-boolean value', () => {
+    expect(() =>
+      validateStreamConfig(({ streamWeb: 'foo' } as unknown) as StreamConfig)
+    ).toThrowError(
+      'Invalid stream config: `streamWeb` cannot be a non-boolean value.'
+    )
+  })
+
+  it('should throw an error when streamWeb is true and a streamWebFolder is not specified', () => {
+    expect(() =>
+      validateStreamConfig(({
+        streamWeb: true,
+        streamWebFolder: ''
+      } as unknown) as StreamConfig)
+    ).toThrowError(
+      'Invalid stream config: `streamWebFolder` cannot be empty, null or undefined when `streamWeb` is true.'
+    )
+  })
+
+  it('should throw an error when webSourcePath is empty', () => {
+    expect(() =>
+      validateStreamConfig(({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: ''
+      } as unknown) as StreamConfig)
+    ).toThrowError(
+      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when webSourcePath is null', () => {
+    expect(() =>
+      validateStreamConfig(({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: null
+      } as unknown) as StreamConfig)
+    ).toThrowError(
+      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should throw an error when webSourcePath is undefined', () => {
+    expect(() =>
+      validateStreamConfig(({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: undefined
+      } as unknown) as StreamConfig)
+    ).toThrowError(
+      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+    )
+  })
+
+  it('should return the stream config when valid', () => {
+    expect(
+      validateStreamConfig({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: '.',
+        assetPaths: []
+      })
+    ).toEqual({
+      streamWeb: true,
+      streamWebFolder: '.',
+      webSourcePath: '.',
+      assetPaths: []
+    })
+  })
+
+  it('should initialise the asset paths if not set', () => {
+    expect(
+      validateStreamConfig(({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: '.'
+      } as unknown) as StreamConfig)
+    ).toEqual({
+      streamWeb: true,
+      streamWebFolder: '.',
+      webSourcePath: '.',
+      assetPaths: []
+    })
+  })
+})

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -15,7 +15,10 @@ import {
   validateDeployConfig,
   validateServiceConfig,
   validateJobConfig,
-  validateStreamConfig
+  validateStreamConfig,
+  validateContextName,
+  validateServerName,
+  validateRepositoryName
 } from './targetValidators'
 
 describe('validateTargetName', () => {
@@ -534,5 +537,43 @@ describe('validateStreamConfig', () => {
       webSourcePath: '.',
       assetPaths: []
     })
+  })
+})
+
+describe('validateContextName', () => {
+  it('should return the default context name when not specified', () => {
+    expect(validateContextName('', ServerType.SasViya)).toEqual(
+      'SAS Job Execution compute context'
+    )
+  })
+
+  it('should return the context name when valid', () => {
+    expect(validateContextName('Test Context', ServerType.SasViya)).toEqual(
+      'Test Context'
+    )
+  })
+})
+
+describe('validateServerName', () => {
+  it('should return the default server name when not specified', () => {
+    expect(validateServerName('', ServerType.Sas9)).toEqual('SASApp')
+  })
+
+  it('should return the server name when valid', () => {
+    expect(validateServerName('Test Server', ServerType.Sas9)).toEqual(
+      'Test Server'
+    )
+  })
+})
+
+describe('validateRepositoryName', () => {
+  it('should return the default repository name when not specified', () => {
+    expect(validateRepositoryName('', ServerType.Sas9)).toEqual('Foundation')
+  })
+
+  it('should return the repository name when valid', () => {
+    expect(validateRepositoryName('Test Repository', ServerType.Sas9)).toEqual(
+      'Test Repository'
+    )
   })
 })

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AuthConfig,
   BuildConfig,
   DeployConfig,
   JobConfig,
@@ -18,7 +19,8 @@ import {
   validateStreamConfig,
   validateContextName,
   validateServerName,
-  validateRepositoryName
+  validateRepositoryName,
+  validateAuthConfig
 } from './targetValidators'
 
 describe('validateTargetName', () => {
@@ -575,5 +577,29 @@ describe('validateRepositoryName', () => {
     expect(validateRepositoryName('Test Repository', ServerType.Sas9)).toEqual(
       'Test Repository'
     )
+  })
+})
+
+describe('validateAuthConfig', () => {
+  it('should throw an error when authConfig is null', () => {
+    expect(() =>
+      validateAuthConfig((null as unknown) as AuthConfig)
+    ).toThrowError('Invalid auth config: JSON cannot be null or undefined.')
+  })
+
+  it('should return the auth config when valid', () => {
+    expect(
+      validateAuthConfig({
+        access_token: 'T35T',
+        refresh_token: 'R3FR35H',
+        client: 'CL13NT',
+        secret: '53CR3T'
+      })
+    ).toEqual({
+      access_token: 'T35T',
+      refresh_token: 'R3FR35H',
+      client: 'CL13NT',
+      secret: '53CR3T'
+    })
   })
 })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -78,26 +78,23 @@ export const validateAppLoc = (appLoc: string): string => {
   return appLoc
 }
 
-export const validateBuildConfig = (buildConfig: BuildConfig): BuildConfig => {
+export const validateBuildConfig = (
+  buildConfig: BuildConfig,
+  defaultName: string
+): BuildConfig => {
   if (!buildConfig) {
     throw new Error('Invalid build config: JSON cannot be null or undefined.')
   }
   if (!buildConfig.buildOutputFileName) {
-    throw new Error(
-      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
-    )
+    buildConfig.buildOutputFileName = `${defaultName}.sas`
   }
 
   if (!buildConfig.initProgram) {
-    throw new Error(
-      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
-    )
+    buildConfig.initProgram = ''
   }
 
   if (!buildConfig.termProgram) {
-    throw new Error(
-      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
-    )
+    buildConfig.termProgram = ''
   }
 
   if (!buildConfig.macroVars) {
@@ -115,15 +112,11 @@ export const validateServiceConfig = (
   }
 
   if (!serviceConfig.initProgram) {
-    throw new Error(
-      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
-    )
+    serviceConfig.initProgram = ''
   }
 
   if (!serviceConfig.termProgram) {
-    throw new Error(
-      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
-    )
+    serviceConfig.termProgram = ''
   }
 
   if (!serviceConfig.serviceFolders) {
@@ -143,15 +136,11 @@ export const validateJobConfig = (jobConfig: JobConfig): JobConfig => {
   }
 
   if (!jobConfig.initProgram) {
-    throw new Error(
-      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
-    )
+    jobConfig.initProgram = ''
   }
 
   if (!jobConfig.termProgram) {
-    throw new Error(
-      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
-    )
+    jobConfig.termProgram = ''
   }
 
   if (!jobConfig.jobFolders) {

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -1,6 +1,7 @@
 import validUrl from 'valid-url'
 import { ServerType } from '.'
 import {
+  AuthConfig,
   BuildConfig,
   DeployConfig,
   JobConfig,
@@ -80,6 +81,14 @@ export const validateAppLoc = (appLoc: string): string => {
   }
 
   return appLoc
+}
+
+export const validateAuthConfig = (authConfig: AuthConfig): AuthConfig => {
+  if (!authConfig) {
+    throw new Error('Invalid auth config: JSON cannot be null or undefined.')
+  }
+
+  return authConfig
 }
 
 export const validateBuildConfig = (

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -8,6 +8,10 @@ import {
   StreamConfig
 } from './config'
 
+const DEFAULT_CONTEXT_NAME = 'SAS Job Execution compute context'
+const DEFAULT_SERVER_NAME = 'SASApp'
+const DEFAULT_REPOSITORY_NAME = 'Foundation'
+
 export const validateServerType = (serverType: any): ServerType => {
   if (!serverType) {
     throw new Error(
@@ -207,4 +211,37 @@ export const validateStreamConfig = (
   }
 
   return streamConfig
+}
+
+export const validateContextName = (
+  contextName: string,
+  serverType: ServerType
+): string => {
+  if (serverType === ServerType.SasViya && !contextName) {
+    return DEFAULT_CONTEXT_NAME
+  }
+
+  return contextName
+}
+
+export const validateServerName = (
+  serverName: string,
+  serverType: ServerType
+): string => {
+  if (serverType === ServerType.Sas9 && !serverName) {
+    return DEFAULT_SERVER_NAME
+  }
+
+  return serverName
+}
+
+export const validateRepositoryName = (
+  repositoryName: string,
+  serverType: ServerType
+): string => {
+  if (serverType === ServerType.Sas9 && !repositoryName) {
+    return DEFAULT_REPOSITORY_NAME
+  }
+
+  return repositoryName
 }

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -1,0 +1,221 @@
+import validUrl from 'valid-url'
+import { ServerType } from '.'
+import {
+  BuildConfig,
+  DeployConfig,
+  JobConfig,
+  ServiceConfig,
+  StreamConfig
+} from './config'
+
+export const validateServerType = (serverType: any): ServerType => {
+  if (!serverType) {
+    throw new Error(
+      'Invalid server type: `serverType` cannot be null or undefined.'
+    )
+  }
+
+  if (!(serverType === ServerType.Sas9 || serverType === ServerType.SasViya)) {
+    throw new Error(
+      `Invalid server type: Supported values for  \`serverType\` are ${ServerType.SasViya} and ${ServerType.Sas9}.`
+    )
+  }
+
+  return serverType as ServerType
+}
+
+export const validateTargetName = (targetName: string): string => {
+  if (!targetName) {
+    throw new Error(
+      'Invalid target name: `name` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (targetName.trim().includes(' ')) {
+    throw new Error('Invalid target name: `name` cannot include spaces.')
+  }
+
+  if (!/^[a-zA-Z0-9]+$/i.test(targetName)) {
+    throw new Error(
+      'Invalid target name: `name` can only contain alphanumeric characters.'
+    )
+  }
+
+  return targetName
+}
+
+export const validateServerUrl = (serverUrl: string): string => {
+  if (serverUrl === null || serverUrl === undefined) {
+    throw new Error(
+      'Invalid server URL: `serverUrl` cannot be null or undefined.'
+    )
+  }
+
+  if (
+    serverUrl !== '' &&
+    !validUrl.isHttpUri(serverUrl) &&
+    !validUrl.isHttpsUri(serverUrl)
+  ) {
+    throw new Error(
+      'Invalid server URL: `serverUrl` should either be an empty string or a valid URL of the form http(s)://your-server.com(:port).'
+    )
+  }
+
+  return serverUrl
+}
+
+export const validateAppLoc = (appLoc: string): string => {
+  if (!appLoc) {
+    throw new Error(
+      'Invalid app location: `appLoc` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!appLoc.startsWith('/')) {
+    throw new Error('Invalid app location: `appLoc` must start with a `/`.')
+  }
+
+  return appLoc
+}
+
+export const validateBuildConfig = (buildConfig: BuildConfig): BuildConfig => {
+  if (!buildConfig) {
+    throw new Error('Invalid build config: JSON cannot be null or undefined.')
+  }
+  if (!buildConfig.buildOutputFileName) {
+    throw new Error(
+      'Invalid build config: `buildOutputFileName` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!buildConfig.initProgram) {
+    throw new Error(
+      'Invalid build config: `initProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!buildConfig.termProgram) {
+    throw new Error(
+      'Invalid build config: `termProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!buildConfig.macroVars) {
+    buildConfig.macroVars = {}
+  }
+
+  return buildConfig
+}
+
+export const validateServiceConfig = (
+  serviceConfig: ServiceConfig
+): ServiceConfig => {
+  if (!serviceConfig) {
+    throw new Error('Invalid service config: JSON cannot be null or undefined.')
+  }
+
+  if (!serviceConfig.initProgram) {
+    throw new Error(
+      'Invalid service config: `initProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!serviceConfig.termProgram) {
+    throw new Error(
+      'Invalid service config: `termProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!serviceConfig.serviceFolders) {
+    serviceConfig.serviceFolders = []
+  }
+
+  if (!serviceConfig.macroVars) {
+    serviceConfig.macroVars = {}
+  }
+
+  return serviceConfig
+}
+
+export const validateJobConfig = (jobConfig: JobConfig): JobConfig => {
+  if (!jobConfig) {
+    throw new Error('Invalid job config: JSON cannot be null or undefined.')
+  }
+
+  if (!jobConfig.initProgram) {
+    throw new Error(
+      'Invalid job config: `initProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!jobConfig.termProgram) {
+    throw new Error(
+      'Invalid job config: `termProgram` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!jobConfig.jobFolders) {
+    jobConfig.jobFolders = []
+  }
+
+  if (!jobConfig.macroVars) {
+    jobConfig.macroVars = {}
+  }
+
+  return jobConfig
+}
+
+export const validateDeployConfig = (
+  deployConfig: DeployConfig
+): DeployConfig => {
+  if (!deployConfig) {
+    throw new Error('Invalid deploy config: JSON cannot be null or undefined.')
+  }
+
+  if (
+    deployConfig.deployServicePack !== true &&
+    deployConfig.deployServicePack !== false
+  ) {
+    throw new Error(
+      'Invalid deploy config: `deployServicePack` cannot be a non-boolean value.'
+    )
+  }
+
+  if (!deployConfig.deployScripts) {
+    deployConfig.deployScripts = []
+  }
+
+  return deployConfig
+}
+
+export const validateStreamConfig = (
+  streamConfig: StreamConfig
+): StreamConfig => {
+  if (!streamConfig) {
+    throw new Error('Invalid stream config: JSON cannot be null or undefined.')
+  }
+
+  if (streamConfig.streamWeb !== true && streamConfig.streamWeb !== false) {
+    throw new Error(
+      'Invalid stream config: `streamWeb` cannot be a non-boolean value.'
+    )
+  }
+
+  if (streamConfig.streamWeb && !streamConfig.streamWebFolder) {
+    throw new Error(
+      'Invalid stream config: `streamWebFolder` cannot be empty, null or undefined when `streamWeb` is true.'
+    )
+  }
+
+  if (!streamConfig.webSourcePath) {
+    throw new Error(
+      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+    )
+  }
+
+  if (!streamConfig.assetPaths) {
+    streamConfig.assetPaths = []
+  }
+
+  return streamConfig
+}


### PR DESCRIPTION
## Issue

Closes https://github.com/sasjs/utils/issues/10

## Intent

Create new model for `Target` and validate all the fields.

## Implementation

* Created interfaces for various types of config.
* Created `Target` class that parses and validates the JSON in the constructor.
* Added functions to validate each part of the JSON.
* Added nearly 100 unit tests for various different combinations of values.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`) - Migrating  the CLI to use this new model will be a big task that I'll do after this approach has been okayed.
