### PR TITLE
feat(error-modifier): added prefixMessage utility

### DIFF
--- a/src/error/errorModifier.spec.ts
+++ b/src/error/errorModifier.spec.ts
@@ -1,0 +1,79 @@
+import { prefixMessage } from './errorModifier'
+
+const messagePrefix = 'Test Prefix. '
+
+describe('errorModifier', () => {
+  it('should add prefix to error of type string', () => {
+    const error = 'Some Error'
+
+    expect(prefixMessage(error, messagePrefix)).toEqual(
+      `${messagePrefix}${error}`
+    )
+  })
+
+  it('should add prefix to error of object with message property', () => {
+    const errorMessage = 'Some Message'
+    const error = {
+      message: errorMessage
+    }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      message: `${messagePrefix}${errorMessage}`
+    })
+  })
+
+  it('should add prefix to error of object', () => {
+    const error = {}
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      message: messagePrefix
+    })
+  })
+
+  it('should add prefix to error of object with body property', () => {
+    const error = { body: {} }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      ...error,
+      message: messagePrefix
+    })
+  })
+
+  it('should add prefix to error of object with body and message properties', () => {
+    const errorMessage = 'Some Message'
+    const error = { body: { message: errorMessage } }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      ...error,
+      message: messagePrefix + errorMessage
+    })
+  })
+
+  it('should add prefix to error of object with body property of type string parsable to object', () => {
+    const errorMessage = 'Some Message'
+    const error = { body: `{ "description": "${errorMessage}" }` }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      body: { description: errorMessage, message: messagePrefix }
+    })
+  })
+
+  it('should add prefix to error of object with body property of type string parsable to object with message property', () => {
+    const errorMessage = 'Some Message'
+    const error = { body: `{ "message": "${errorMessage}" }` }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      body: { message: messagePrefix + errorMessage }
+    })
+  })
+
+  it('should add prefix to error of object with body property of type string not parsable to object', () => {
+    const errorMessage = 'Some Message'
+    const error = { body: `{ "message: "${errorMessage}" }` }
+
+    expect(prefixMessage(error, messagePrefix)).toEqual({
+      ...error,
+      message: messagePrefix
+    })
+  })
+})

--- a/src/error/errorModifier.ts
+++ b/src/error/errorModifier.ts
@@ -1,0 +1,41 @@
+import { Error } from '../types/index'
+
+export const prefixMessage = (err: Error | string, messagePrefix: string) => {
+  if (typeof err === 'object') {
+    if (err.hasOwnProperty('message')) {
+      err.message = messagePrefix + err.message
+    } else {
+      if (err.hasOwnProperty('body')) {
+        if (typeof err.body === 'object') {
+          err.message = err.body.message
+            ? messagePrefix + err.body.message
+            : messagePrefix
+        }
+
+        if (typeof err.body === 'string') {
+          let body
+
+          try {
+            body = JSON.parse(err.body)
+          } catch (error) {
+            err.message = messagePrefix
+
+            return err
+          }
+
+          body.message = body.message
+            ? messagePrefix + body.message
+            : messagePrefix
+
+          err.body = body
+
+          return err
+        }
+      } else return { ...err, message: messagePrefix }
+    }
+  }
+
+  if (typeof err === 'string') err = messagePrefix + err
+
+  return err
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,0 +1,1 @@
+export { prefixMessage } from './errorModifier'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './sasAuthResponse'
 export * from './serverType'
+export * from './serverError'
 export { Target } from './target'

--- a/src/types/serverError.ts
+++ b/src/types/serverError.ts
@@ -1,0 +1,4 @@
+export interface Error {
+  body?: { message?: string } | string
+  message?: string
+}


### PR DESCRIPTION
## Intent

Create a utility that will append message prefix to error object.

## Implementation

1. `errorModifier.ts`
2. `errorModifier.spec.ts`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/102585440-8073e980-4119-11eb-85db-3d427162ce49.png)
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
