### PR TITLE
fix(server-url): set serverUrl to empty string when null or undefined

### DIFF
--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -124,7 +124,7 @@ describe('validateAppLoc', () => {
 })
 
 describe('validateServerUrl', () => {
-  it('should set server URL to the empty string when it is is null', () => {
+  it('should set server URL to the empty string when it is null', () => {
     expect(validateServerUrl((null as unknown) as string)).toEqual('')
   })
 

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -124,18 +124,12 @@ describe('validateAppLoc', () => {
 })
 
 describe('validateServerUrl', () => {
-  it('should throw an error when server URL is null', () => {
-    expect(() => validateServerUrl((null as unknown) as string)).toThrowError(
-      'Invalid server URL: `serverUrl` cannot be null or undefined.'
-    )
+  it('should set server URL to the empty string when it is is null', () => {
+    expect(validateServerUrl((null as unknown) as string)).toEqual('')
   })
 
-  it('should throw an error when server URL is undefined', () => {
-    expect(() =>
-      validateServerUrl((undefined as unknown) as string)
-    ).toThrowError(
-      'Invalid server URL: `serverUrl` cannot be null or undefined.'
-    )
+  it('should set server URL to the empty string when it is undefined', () => {
+    expect(validateServerUrl((undefined as unknown) as string)).toEqual('')
   })
 
   it('should throw an error when server URL is not a valid URL', () => {

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -51,9 +51,7 @@ export const validateTargetName = (targetName: string): string => {
 
 export const validateServerUrl = (serverUrl: string): string => {
   if (serverUrl === null || serverUrl === undefined) {
-    throw new Error(
-      'Invalid server URL: `serverUrl` cannot be null or undefined.'
-    )
+    serverUrl = ''
   }
 
   if (


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/389

## Intent

Prevent errors being thrown when the `serverUrl` is `null` or `undefined`.

## Implementation

* Removed validation error clause for `serverUrl`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
