### PR TITLE
fix(target): include server-specific attributes in target JSON

### DIFF
--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -307,4 +307,45 @@ describe('Target', () => {
       deployServicePack: false
     })
   })
+
+  it('should include context name in JSON when server type is SASVIYA', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test',
+      contextName: 'Test Context'
+    })
+
+    const json = target.toJson()
+
+    expect(json.name).toEqual(target.name)
+    expect(json.serverUrl).toEqual(target.serverUrl)
+    expect(json.serverType).toEqual(target.serverType)
+    expect(json.appLoc).toEqual(target.appLoc)
+    expect(json.contextName).toEqual(target.contextName)
+    expect(json.serverName).toBeUndefined()
+    expect(json.repositoryName).toBeUndefined()
+  })
+
+  it('should include server name and repository name in JSON when server type is SAS9', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      serverName: 'Test Server',
+      repositoryName: 'Test Repository'
+    })
+
+    const json = target.toJson()
+
+    expect(json.name).toEqual(target.name)
+    expect(json.serverUrl).toEqual(target.serverUrl)
+    expect(json.serverType).toEqual(target.serverType)
+    expect(json.appLoc).toEqual(target.appLoc)
+    expect(json.contextName).toBeUndefined()
+    expect(json.serverName).toEqual(target.serverName)
+    expect(json.repositoryName).toEqual(target.repositoryName)
+  })
 })

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -174,7 +174,7 @@ export class Target implements TargetInterface {
   }
 
   toJson(): TargetInterface {
-    return {
+    const json: TargetInterface = {
       name: this.name,
       serverUrl: this.serverUrl,
       serverType: this.serverType,
@@ -216,5 +216,14 @@ export class Target implements TargetInterface {
         deployServicePack: false
       }
     }
+
+    if (this.serverType === ServerType.SasViya) {
+      json.contextName = this.contextName
+    } else {
+      json.serverName = this.serverName
+      json.repositoryName = this.repositoryName
+    }
+
+    return json
   }
 }


### PR DESCRIPTION
## Issue

https://github.com/sasjs/utils/issues/17

## Intent

Add server-specific attributes to the saved JSON.

## Implementation

* Conditionally add attributes to JSON based on server type.
* Add tests to cover the new scenarios.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
