### PR TITLE
feat(DocConfig): added 'DocConfig' for Configuration

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,16 +3,8 @@ export interface Config {
   initProgram: string
   termProgram: string
 }
-export interface DocConfig {
-  displayMacroCore: boolean
-  outDirectory: string
-}
 export interface BuildConfig extends Config {
   buildOutputFileName: string
-}
-export interface DeployConfig {
-  deployServicePack: boolean
-  deployScripts: string[]
 }
 export interface ServiceConfig extends Config {
   serviceFolders: string[]
@@ -20,13 +12,20 @@ export interface ServiceConfig extends Config {
 export interface JobConfig extends Config {
   jobFolders: string[]
 }
+export interface DocConfig {
+  displayMacroCore: boolean
+  outDirectory: string
+}
+export interface DeployConfig {
+  deployServicePack: boolean
+  deployScripts: string[]
+}
 export interface StreamConfig {
   assetPaths: string[]
   streamWeb: boolean
   streamWebFolder: string
   webSourcePath: string
 }
-
 export interface AuthConfig {
   access_token: string
   refresh_token: string

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,10 @@ export interface Config {
   initProgram: string
   termProgram: string
 }
+export interface DocConfig {
+  displayMacroCore: boolean
+  outDirectory: string
+}
 export interface BuildConfig extends Config {
   buildOutputFileName: string
 }


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/415

## Intent

Needs to have `DocConfig` object at root level in configuration

## Implementation

Added `DocConfig` to `config.ts`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
