### PR TITLE
fix(handle-cancel): exit gracefully when user cancels input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -728,8 +728,7 @@
     "@types/node": {
       "version": "14.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-      "dev": true
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -747,7 +746,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
       "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/sasjs/utils#readme",
   "devDependencies": {
     "@types/jest": "^26.0.15",
-    "@types/prompts": "^2.0.9",
     "@types/valid-url": "^1.0.3",
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
@@ -42,6 +41,7 @@
   "dependencies": {
     "consola": "^2.15.0",
     "prompts": "^2.4.0",
+    "@types/prompts": "^2.0.9",
     "valid-url": "^1.0.9"
   }
 }

--- a/src/input/readAndValidateInput.spec.ts
+++ b/src/input/readAndValidateInput.spec.ts
@@ -5,6 +5,7 @@ import {
   getString,
   getUrl,
   InputType,
+  onCancel,
   readAndValidateInput
 } from './readAndValidateInput'
 import prompts from 'prompts'
@@ -28,14 +29,16 @@ describe('getString', () => {
     await getString(message, validator)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
-    expect(prompts.prompt).toHaveBeenCalledWith({
-      type: 'text',
-      name: 'text',
-      initial: '',
-      message,
-      validate: validator,
-      choices: []
-    })
+    expect(prompts.prompt).toHaveBeenCalledWith(
+      {
+        type: 'text',
+        name: 'text',
+        initial: '',
+        message,
+        validate: validator
+      },
+      { onCancel }
+    )
     done()
   })
 
@@ -82,14 +85,16 @@ describe('getNumber', () => {
     await getNumber(message, validator, defaultValue)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
-    expect(prompts.prompt).toHaveBeenCalledWith({
-      type: 'number',
-      name: 'number',
-      initial: defaultValue,
-      message,
-      validate: validator,
-      choices: []
-    })
+    expect(prompts.prompt).toHaveBeenCalledWith(
+      {
+        type: 'number',
+        name: 'number',
+        initial: defaultValue,
+        message,
+        validate: validator
+      },
+      { onCancel }
+    )
     done()
   })
 
@@ -151,14 +156,16 @@ describe('getUrl', () => {
     await getUrl(message, errorMessage)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
-    expect(prompts.prompt).toHaveBeenCalledWith({
-      type: 'text',
-      name: 'url',
-      initial: '',
-      message,
-      validate: expect.anything(),
-      choices: []
-    })
+    expect(prompts.prompt).toHaveBeenCalledWith(
+      {
+        type: 'text',
+        name: 'url',
+        initial: '',
+        message,
+        validate: expect.anything()
+      },
+      { onCancel }
+    )
     done()
   })
 
@@ -203,14 +210,16 @@ describe('getConfirmation', () => {
     await getConfirmation(message, false)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
-    expect(prompts.prompt).toHaveBeenCalledWith({
-      type: 'confirm',
-      name: 'confirm',
-      initial: false,
-      message,
-      validate: confirmationValidator,
-      choices: []
-    })
+    expect(prompts.prompt).toHaveBeenCalledWith(
+      {
+        type: 'confirm',
+        name: 'confirm',
+        initial: false,
+        message,
+        validate: confirmationValidator
+      },
+      { onCancel }
+    )
     done()
   })
 
@@ -235,7 +244,10 @@ describe('getChoice', () => {
   it('should call prompts to get a selection', async (done) => {
     const message = 'Choose: '
     const errorMessage = 'Invalid choice.'
-    const choices = [{ title: 'Option 1' }, { title: 'Option 2' }]
+    const choices = [
+      { title: 'Option 1', value: 1 },
+      { title: 'Option 2', value: 2 }
+    ]
     jest
       .spyOn(prompts, 'prompt')
       .mockImplementation(() => Promise.resolve({ choice: 1 }))
@@ -243,21 +255,27 @@ describe('getChoice', () => {
     await getChoice(message, errorMessage, choices)
 
     expect(prompts.prompt).toHaveBeenCalledTimes(1)
-    expect(prompts.prompt).toHaveBeenCalledWith({
-      type: 'select',
-      name: 'choice',
-      initial: 0,
-      message,
-      validate: expect.anything(),
-      choices
-    })
+    expect(prompts.prompt).toHaveBeenCalledWith(
+      {
+        type: 'select',
+        name: 'choice',
+        initial: 0,
+        message,
+        validate: expect.anything(),
+        choices
+      },
+      { onCancel }
+    )
     done()
   })
 
   it('should throw an error with a non-number choice', async (done) => {
     const message = 'Choose: '
     const errorMessage = 'Invalid choice.'
-    const choices = [{ title: 'Option 1' }, { title: 'Option 2' }]
+    const choices = [
+      { title: 'Option 1', value: 1 },
+      { title: 'Option 2', value: 2 }
+    ]
     jest
       .spyOn(prompts, 'prompt')
       .mockImplementation(() => Promise.resolve({ choice: 'abc' }))
@@ -304,7 +322,7 @@ describe('readAndValidateInput', () => {
 
     await expect(
       readAndValidateInput('number', 'choice', 'Choose', (v) => !!v, 1, [
-        { title: 'Test' }
+        { title: 'Test', value: 1 }
       ])
     ).rejects.toThrowError(
       'Choices are only supported with the `select` input type.'

--- a/src/input/readAndValidateInput.ts
+++ b/src/input/readAndValidateInput.ts
@@ -12,7 +12,7 @@ export type InputValidator = (
 export interface Choice {
   title: string
   description?: string
-  value?: string | number
+  value: string | number
 }
 
 const defaultErrorMessage = 'Invalid input.'
@@ -23,6 +23,11 @@ const isValidInputType = (type: any): boolean =>
   type === 'select' ||
   type === 'confirm' ||
   type === 'url'
+
+export const onCancel = () => {
+  console.error('Input cancelled. Exiting...')
+  process.exit(1)
+}
 
 export const getNumber = async (
   message: string,
@@ -108,7 +113,7 @@ export const getChoice = async (
     choice !== null &&
     choice !== undefined
   ) {
-    return choice + 1
+    return choice
   }
 
   throw new Error(errorMessage)
@@ -157,12 +162,32 @@ export const readAndValidateInput = async (
     )
   }
 
-  return await prompts.prompt({
-    type,
-    name: fieldName,
-    initial: defaultValue,
-    message,
-    choices,
-    validate: validator
-  })
+  if (type === 'select') {
+    return await prompts(
+      {
+        type,
+        name: fieldName,
+        initial: defaultValue,
+        message,
+        choices,
+        validate: validator
+      },
+      {
+        onCancel
+      }
+    )
+  }
+
+  return await prompts(
+    {
+      type,
+      name: fieldName,
+      initial: defaultValue,
+      message,
+      validate: validator
+    },
+    {
+      onCancel
+    }
+  )
 }


### PR DESCRIPTION
## Issue

https://github.com/sasjs/utils/issues/22

## Intent

Exit quietly with a one-line message when the user presses `Ctrl+C`.

## Implementation

* Added `onCancel` callback to `prompts`.
* Made `value` attribute mandatory for choices.
* Fixed tests.
* Made `@types/prompts` a regular dependency so that it can be used by the CLI to recognise `prompts` typings correctly.

## Before
![image](https://user-images.githubusercontent.com/2980428/107148814-33f49f80-694d-11eb-8ff1-8bcd519c81d3.png)

## After
![image](https://user-images.githubusercontent.com/2980428/107148834-4ec71400-694d-11eb-8d1c-885ef9cef734.png)

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
