### PR TITLE
fix: docConfig properties are made optional + disableLineage is added

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,9 +13,10 @@ export interface JobConfig extends Config {
   jobFolders: string[]
 }
 export interface DocConfig {
-  displayMacroCore: boolean
-  outDirectory: string
-  dataControllerUrl: string
+  displayMacroCore?: boolean
+  disableLineage?: boolean
+  outDirectory?: string
+  dataControllerUrl?: string
 }
 export interface DeployConfig {
   deployServicePack: boolean

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -204,11 +204,7 @@ export class Target implements TargetInterface {
       appLoc: this.appLoc,
       macroFolders: this.macroFolders,
       programFolders: this.programFolders,
-      docConfig: this.docConfig || {
-        displayMacroCore: true,
-        outDirectory: '',
-        dataControllerUrl: ''
-      },
+      docConfig: this.docConfig,
       authConfig: this.authConfig || {
         access_token: '',
         refresh_token: '',

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -642,23 +642,186 @@ describe('validateAuthConfig', () => {
 })
 
 describe('validateDocConfig', () => {
-  it('should throw an error when docConfig is null', () => {
-    expect(() =>
-      validateDocConfig((null as unknown) as DocConfig)
-    ).toThrowError('Invalid doc config: JSON cannot be null or undefined.')
+  it('should return the doc config when null/undefined', () => {
+    expect(validateDocConfig((null as unknown) as DocConfig)).toMatchObject({})
+    expect(
+      validateDocConfig((undefined as unknown) as DocConfig)
+    ).toMatchObject({})
+    expect(validateDocConfig({} as DocConfig)).toMatchObject({})
   })
 
   it('should return the doc config when valid', () => {
     expect(
       validateDocConfig({
-        displayMacroCore: false,
+        displayMacroCore: true,
+        disableLineage: false,
         outDirectory: '',
+        dataControllerUrl: ''
+      })
+    ).toEqual({
+      displayMacroCore: true,
+      disableLineage: false,
+      outDirectory: '',
+      dataControllerUrl: ''
+    })
+
+    expect(
+      validateDocConfig({
+        displayMacroCore: false,
+        disableLineage: true,
+        outDirectory: 'my-doc',
         dataControllerUrl: 'http://my-server.com:1234'
       })
     ).toEqual({
       displayMacroCore: false,
-      outDirectory: '',
+      disableLineage: true,
+      outDirectory: 'my-doc',
       dataControllerUrl: 'http://my-server.com:1234'
+    })
+
+    expect(validateDocConfig({})).toEqual({
+      displayMacroCore: undefined,
+      disableLineage: undefined,
+      outDirectory: undefined,
+      dataControllerUrl: undefined
+    })
+  })
+
+  it('should set dataControllerUrl to undefined when it is null/undefined', () => {
+    expect(
+      validateDocConfig({
+        dataControllerUrl: (null as unknown) as string
+      })
+    ).toEqual({
+      dataControllerUrl: undefined
+    })
+
+    expect(
+      validateDocConfig({
+        dataControllerUrl: undefined
+      })
+    ).toEqual({
+      dataControllerUrl: undefined
+    })
+  })
+
+  it('should throw an error when dataControllerUrl is not a valid URL', () => {
+    expect(() =>
+      validateDocConfig({
+        dataControllerUrl: 'my-domain-name'
+      })
+    ).toThrowError(
+      'Invalid Data Controller Url: `dataControllerUrl` should either be an empty string or a valid URL of the form http(s)://your-server.com(:port).'
+    )
+  })
+
+  it('should return the dataControllerUrl when empty', () => {
+    expect(
+      validateDocConfig({
+        dataControllerUrl: ''
+      })
+    ).toEqual({
+      dataControllerUrl: ''
+    })
+  })
+
+  it('should return the dataControllerUrl when valid', () => {
+    expect(
+      validateDocConfig({
+        dataControllerUrl: 'http://my-server.com:1234'
+      })
+    ).toEqual({
+      dataControllerUrl: 'http://my-server.com:1234'
+    })
+  })
+
+  it('should set outDirectory to undefined when it is not string', () => {
+    expect(
+      validateDocConfig({
+        outDirectory: (null as unknown) as string
+      })
+    ).toEqual({
+      outDirectory: undefined
+    })
+
+    expect(
+      validateDocConfig({
+        outDirectory: (false as unknown) as string
+      })
+    ).toEqual({
+      outDirectory: undefined
+    })
+
+    expect(
+      validateDocConfig({
+        outDirectory: undefined
+      })
+    ).toEqual({
+      outDirectory: undefined
+    })
+  })
+
+  it('should return the outDirectory when empty', () => {
+    expect(
+      validateDocConfig({
+        outDirectory: ''
+      })
+    ).toEqual({
+      outDirectory: ''
+    })
+  })
+
+  it('should return the outDirectory when valid', () => {
+    expect(
+      validateDocConfig({
+        outDirectory: 'my-docs'
+      })
+    ).toEqual({
+      outDirectory: 'my-docs'
+    })
+  })
+
+  it('should set displayMacroCore/disableLineage to undefined when it is not boolean', () => {
+    expect(
+      validateDocConfig({
+        displayMacroCore: (null as unknown) as boolean,
+        disableLineage: (null as unknown) as boolean
+      })
+    ).toEqual({
+      displayMacroCore: undefined,
+      disableLineage: undefined
+    })
+
+    expect(
+      validateDocConfig({
+        displayMacroCore: undefined,
+        disableLineage: undefined
+      })
+    ).toEqual({
+      displayMacroCore: undefined,
+      disableLineage: undefined
+    })
+  })
+
+  it('should return the displayMacroCore/disableLineage when valid', () => {
+    expect(
+      validateDocConfig({
+        displayMacroCore: true,
+        disableLineage: true
+      })
+    ).toEqual({
+      displayMacroCore: true,
+      disableLineage: true
+    })
+
+    expect(
+      validateDocConfig({
+        displayMacroCore: false,
+        disableLineage: false
+      })
+    ).toEqual({
+      displayMacroCore: false,
+      disableLineage: false
     })
   })
 })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -98,19 +98,33 @@ export const validateAppLoc = (appLoc: string): string => {
 
 export const validateDocConfig = (docConfig: DocConfig): DocConfig => {
   if (!docConfig) {
-    throw new Error('Invalid doc config: JSON cannot be null or undefined.')
+    docConfig = {}
   }
 
-  if (docConfig.displayMacroCore === undefined) {
-    docConfig.displayMacroCore = true
+  if (typeof docConfig.displayMacroCore !== 'boolean') {
+    docConfig.displayMacroCore = undefined
   }
 
-  if (!docConfig.outDirectory) {
-    docConfig.outDirectory = ''
+  if (typeof docConfig.disableLineage !== 'boolean') {
+    docConfig.disableLineage = undefined
   }
 
-  if (!docConfig.dataControllerUrl) {
-    docConfig.dataControllerUrl = ''
+  if (typeof docConfig.outDirectory !== 'string') {
+    docConfig.outDirectory = undefined
+  }
+
+  if (typeof docConfig.dataControllerUrl === 'string') {
+    if (
+      docConfig.dataControllerUrl !== '' &&
+      !validUrl.isHttpUri(docConfig.dataControllerUrl) &&
+      !validUrl.isHttpsUri(docConfig.dataControllerUrl)
+    ) {
+      throw new Error(
+        'Invalid Data Controller Url: `dataControllerUrl` should either be an empty string or a valid URL of the form http(s)://your-server.com(:port).'
+      )
+    }
+  } else {
+    docConfig.dataControllerUrl = undefined
   }
 
   return docConfig


### PR DESCRIPTION
## Issue

1. Make all properties of `docConfig` optional, 
- `docConfig` is present at `root` and `Target` levels, 
- `docConfig.xyz` of Target has precedence over root level's if present, so defaults set to undefined
2. added `disableLineage` as per [issue](https://github.com/sasjs/cli/issues/478)

## Intent

What this PR intends to achieve.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
