### PR TITLE
feat(stream-config): make stream service name configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Check Code Style
         run: npm run lint
       - name: Run Unit Tests
-        run: npm test
+        uses: mattallty/jest-github-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          test-command: 'npm test'
       - name: Build Package
         run: npm run package:lib
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,7 @@ jobs:
       - name: Check Code Style
         run: npm run lint
       - name: Run Unit Tests
-        uses: ziishaned/jest-reporter-action@v0.0.1
-        with:
-          github-token: ${{ secrets.GH_TOKEN }}
-          test-command: 'npm test'
+        run: npm test
       - name: Build Package
         run: npm run package:lib
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,9 @@ jobs:
       - name: Check Code Style
         run: npm run lint
       - name: Run Unit Tests
-        uses: mattallty/jest-github-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        uses: ziishaned/jest-reporter-action@v0.0.1
         with:
+          github-token: ${{ secrets.GH_TOKEN }}
           test-command: 'npm test'
       - name: Build Package
         run: npm run package:lib

--- a/src/input/readAndValidateInput.spec.ts
+++ b/src/input/readAndValidateInput.spec.ts
@@ -329,3 +329,15 @@ describe('readAndValidateInput', () => {
     )
   })
 })
+
+describe('onCancel', () => {
+  it('should log an error and exit', () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+    jest.spyOn(process, 'exit').mockImplementationOnce(() => 0 as never)
+
+    onCancel()
+
+    expect(console.error).toHaveBeenCalledWith('Input cancelled. Exiting...')
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,6 +27,7 @@ export interface StreamConfig {
   streamWeb: boolean
   streamWebFolder: string
   webSourcePath: string
+  streamServiceName: string
 }
 export interface AuthConfig {
   access_token: string

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -167,6 +167,29 @@ describe('Target', () => {
     expect(target.jobConfig!.termProgram).toEqual('term')
   })
 
+  it('should create an instance with doc config when the JSON is valid', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      docConfig: {
+        displayMacroCore: true,
+        dataControllerUrl: 'https://test.com',
+        disableLineage: false,
+        outDirectory: '.'
+      }
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.docConfig).toBeTruthy()
+    expect(target.docConfig!.displayMacroCore).toEqual(true)
+    expect(target.docConfig!.dataControllerUrl).toEqual('https://test.com')
+    expect(target.docConfig!.disableLineage).toEqual(false)
+    expect(target.docConfig!.outDirectory).toEqual('.')
+  })
+
   it('should create an instance with stream config when the JSON is valid', () => {
     const target = new Target({
       name: 'test',
@@ -300,7 +323,8 @@ describe('Target', () => {
       streamWebFolder: '',
       streamWeb: false,
       webSourcePath: '',
-      assetPaths: []
+      assetPaths: [],
+      streamServiceName: ''
     })
     expect(json.deployConfig).toEqual({
       deployScripts: [],

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -233,6 +233,7 @@ export class Target implements TargetInterface {
         streamWebFolder: '',
         streamWeb: false,
         webSourcePath: '',
+        streamServiceName: '',
         assetPaths: []
       },
       deployConfig: this.deployConfig || {

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -553,17 +553,37 @@ describe('validateStreamConfig', () => {
         streamWeb: true,
         streamWebFolder: '.',
         webSourcePath: '.',
-        assetPaths: []
+        assetPaths: [],
+        streamServiceName: 'streamWebApp'
       })
     ).toEqual({
       streamWeb: true,
       streamWebFolder: '.',
       webSourcePath: '.',
-      assetPaths: []
+      assetPaths: [],
+      streamServiceName: 'streamWebApp'
     })
   })
 
   it('should initialise the asset paths if not set', () => {
+    expect(
+      validateStreamConfig({
+        streamWeb: true,
+        streamWebFolder: '.',
+        webSourcePath: '.',
+        assetPaths: [],
+        streamServiceName: 'test'
+      })
+    ).toEqual({
+      streamWeb: true,
+      streamWebFolder: '.',
+      webSourcePath: '.',
+      assetPaths: [],
+      streamServiceName: 'test'
+    })
+  })
+
+  it('should initialise the stream service name if not set', () => {
     expect(
       validateStreamConfig(({
         streamWeb: true,
@@ -574,7 +594,8 @@ describe('validateStreamConfig', () => {
       streamWeb: true,
       streamWebFolder: '.',
       webSourcePath: '.',
-      assetPaths: []
+      assetPaths: [],
+      streamServiceName: 'clickme'
     })
   })
 })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -259,6 +259,10 @@ export const validateStreamConfig = (
     streamConfig.assetPaths = []
   }
 
+  if (!streamConfig.streamServiceName) {
+    streamConfig.streamServiceName = 'clickme'
+  }
+
   return streamConfig
 }
 


### PR DESCRIPTION
## Issue

https://github.com/sasjs/utils/issues/27

## Intent

Make the stream service name configurable

## Implementation

* Added `streamServiceName` to `streamConfig`.
* Added tests.
* Added missing tests for `docConfig` and `onCancel`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
