### PR TITLE
feat(default-target): add ability to set target as default

### DIFF
--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -58,6 +58,7 @@ describe('Target', () => {
     expect(target.buildConfig!.initProgram).toEqual('')
     expect(target.buildConfig!.termProgram).toEqual('')
     expect(target.buildConfig!.macroVars).toEqual({})
+    expect(target.isDefault).toBeFalsy()
   })
 
   it('should create an instance when the JSON is valid', () => {
@@ -66,7 +67,8 @@ describe('Target', () => {
       serverUrl: '',
       serverType: ServerType.Sas9,
       appLoc: '/test',
-      contextName: 'Test Context'
+      contextName: 'Test Context',
+      isDefault: true
     })
 
     expect(target).toBeTruthy()
@@ -76,6 +78,7 @@ describe('Target', () => {
     expect(target.serverType).toEqual(ServerType.Sas9)
     expect(target.appLoc).toEqual('/test')
     expect(target.contextName).toEqual('Test Context')
+    expect(target.isDefault).toBeTruthy()
   })
 
   it('should create an instance with build config when the JSON is valid', () => {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -44,6 +44,7 @@ interface TargetInterface {
   streamConfig?: StreamConfig
   macroFolders: string[]
   programFolders: string[]
+  isDefault?: boolean
 }
 
 export class Target implements TargetInterface {
@@ -132,6 +133,11 @@ export class Target implements TargetInterface {
   }
   private _repositoryName: string
 
+  get isDefault(): boolean {
+    return this._isDefault
+  }
+  private _isDefault: boolean
+
   constructor(json: any) {
     try {
       if (!json) {
@@ -190,6 +196,8 @@ export class Target implements TargetInterface {
       if (json.programFolders && json.programFolders.length) {
         this._programFolders = json.programFolders
       }
+
+      this._isDefault = !!json.isDefault
     } catch (e) {
       throw new Error(`Error parsing target: ${(e as Error).message}`)
     }


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/utils/issues/30

## Intent

Add the ability to set a target as default.

## Implementation

* Added `isDefault` boolean property to target.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`) - only ran mocked tests as server tests are not affected by this change.
![image](https://user-images.githubusercontent.com/2980428/109468810-11920580-7a65-11eb-94de-0a4546c336a1.png)

- [x] Reviewer is assigned.
