### PR TITLE
fix(is-default): include flag in target JSON

### DIFF
--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -295,6 +295,7 @@ describe('Target', () => {
     const json = target.toJson()
 
     expect(json.name).toEqual(target.name)
+    expect(json.isDefault).toBeFalsy()
     expect(json.serverUrl).toEqual(target.serverUrl)
     expect(json.serverType).toEqual(target.serverType)
     expect(json.appLoc).toEqual(target.appLoc)
@@ -333,6 +334,20 @@ describe('Target', () => {
       deployScripts: [],
       deployServicePack: false
     })
+  })
+
+  it('should include isDefault in JSON', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.SasViya,
+      appLoc: '/test',
+      isDefault: true
+    })
+
+    const json = target.toJson()
+
+    expect(json.isDefault).toBeTruthy()
   })
 
   it('should include context name in JSON when server type is SASVIYA', () => {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -206,6 +206,7 @@ export class Target implements TargetInterface {
   toJson(): TargetInterface {
     const json: TargetInterface = {
       name: this.name,
+      isDefault: !!this.isDefault,
       serverUrl: this.serverUrl,
       serverType: this.serverType,
       allowInsecureRequests: this.allowInsecureRequests,


### PR DESCRIPTION
## Issue

No linked issue.

## Intent

Include `isDefault` property in target JSON.

## Implementation

* Included `isDefault` property in target JSON.
* Added test.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
