### PR TITLE
fix: default value for url

### DIFF
--- a/src/input/readAndValidateInput.ts
+++ b/src/input/readAndValidateInput.ts
@@ -121,14 +121,15 @@ export const getChoice = async (
 
 export const getUrl = async (
   message: string,
-  errorMessage: string
+  errorMessage: string,
+  defaultValue: string = ''
 ): Promise<string> => {
   const { url } = await readAndValidateInput(
     'text',
     'url',
     message,
     (value: string) => urlValidator(value, errorMessage),
-    ''
+    defaultValue
   )
 
   if (!!url || url === '') {


### PR DESCRIPTION
## Issue

When updating current target through `sasjs add target`, need to have default for existing target's `serverUrl`

## Intent

What this PR intends to achieve.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
