### PR TITLE
fix(default-target): add default target field to configuration

### DIFF
--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,0 +1,28 @@
+import {
+  DocConfig,
+  BuildConfig,
+  DeployConfig,
+  ServiceConfig,
+  JobConfig,
+  StreamConfig,
+  AuthConfig
+} from './config'
+import { ServerType } from './serverType'
+import { TargetJson } from './target'
+
+export interface Configuration {
+  $schema?: string
+  allowInsecureRequests?: boolean
+  docConfig?: DocConfig
+  buildConfig?: BuildConfig
+  deployConfig?: DeployConfig
+  serviceConfig?: ServiceConfig
+  authConfig?: AuthConfig
+  jobConfig?: JobConfig
+  streamConfig?: StreamConfig
+  macroFolders?: string[]
+  programFolders?: string[]
+  serverType?: ServerType
+  targets?: TargetJson[]
+  defaultTarget?: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
+export * from './configuration'
 export * from './sasAuthResponse'
 export * from './serverType'
 export * from './serverError'
-export { Target } from './target'
+export * from './target'

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -58,7 +58,6 @@ describe('Target', () => {
     expect(target.buildConfig!.initProgram).toEqual('')
     expect(target.buildConfig!.termProgram).toEqual('')
     expect(target.buildConfig!.macroVars).toEqual({})
-    expect(target.isDefault).toBeFalsy()
   })
 
   it('should create an instance when the JSON is valid', () => {
@@ -67,8 +66,7 @@ describe('Target', () => {
       serverUrl: '',
       serverType: ServerType.Sas9,
       appLoc: '/test',
-      contextName: 'Test Context',
-      isDefault: true
+      contextName: 'Test Context'
     })
 
     expect(target).toBeTruthy()
@@ -78,7 +76,6 @@ describe('Target', () => {
     expect(target.serverType).toEqual(ServerType.Sas9)
     expect(target.appLoc).toEqual('/test')
     expect(target.contextName).toEqual('Test Context')
-    expect(target.isDefault).toBeTruthy()
   })
 
   it('should create an instance with build config when the JSON is valid', () => {
@@ -295,7 +292,6 @@ describe('Target', () => {
     const json = target.toJson()
 
     expect(json.name).toEqual(target.name)
-    expect(json.isDefault).toBeFalsy()
     expect(json.serverUrl).toEqual(target.serverUrl)
     expect(json.serverType).toEqual(target.serverType)
     expect(json.appLoc).toEqual(target.appLoc)
@@ -334,20 +330,6 @@ describe('Target', () => {
       deployScripts: [],
       deployServicePack: false
     })
-  })
-
-  it('should include isDefault in JSON', () => {
-    const target = new Target({
-      name: 'test',
-      serverUrl: '',
-      serverType: ServerType.SasViya,
-      appLoc: '/test',
-      isDefault: true
-    })
-
-    const json = target.toJson()
-
-    expect(json.isDefault).toBeTruthy()
   })
 
   it('should include context name in JSON when server type is SASVIYA', () => {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -191,7 +191,6 @@ export class Target implements TargetJson {
       if (json.programFolders && json.programFolders.length) {
         this._programFolders = json.programFolders
       }
-
     } catch (e) {
       throw new Error(`Error parsing target: ${(e as Error).message}`)
     }

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -26,7 +26,7 @@ import {
   validateAuthConfig
 } from './targetValidators'
 
-interface TargetInterface {
+export interface TargetJson {
   name: string
   serverUrl: string
   serverType: ServerType
@@ -47,7 +47,7 @@ interface TargetInterface {
   isDefault?: boolean
 }
 
-export class Target implements TargetInterface {
+export class Target implements TargetJson {
   get name(): string {
     return this._name
   }
@@ -133,11 +133,6 @@ export class Target implements TargetInterface {
   }
   private _repositoryName: string
 
-  get isDefault(): boolean {
-    return this._isDefault
-  }
-  private _isDefault: boolean
-
   constructor(json: any) {
     try {
       if (!json) {
@@ -197,16 +192,14 @@ export class Target implements TargetInterface {
         this._programFolders = json.programFolders
       }
 
-      this._isDefault = !!json.isDefault
     } catch (e) {
       throw new Error(`Error parsing target: ${(e as Error).message}`)
     }
   }
 
-  toJson(): TargetInterface {
-    const json: TargetInterface = {
+  toJson(): TargetJson {
+    const json: TargetJson = {
       name: this.name,
-      isDefault: !!this.isDefault,
       serverUrl: this.serverUrl,
       serverType: this.serverType,
       allowInsecureRequests: this.allowInsecureRequests,


### PR DESCRIPTION
## Issue

https://github.com/sasjs/utils/issues/30

## Intent

Add `defaultTarget` to top-level configuration object.

## Implementation

* Added interface for `Configuration` - moved over from CLI codebase.
* Changed `TargetInterface` to `TargetJson` and made it public.
* Added `defaultTarget` string field to `Configuration`.
* Removed `isDefault` field from individual targets.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`) - I'm currently making the required changes in the CLI code.
- [x] Reviewer is assigned.
