### PR TITLE
chore: added doxy content variabls to docConfig for customization

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,15 @@ export interface DocConfig {
   enableLineage?: boolean
   outDirectory?: string
   dataControllerUrl?: string
+  doxyContent?: {
+    favIcon: string
+    footer: string
+    header: string
+    layout: string
+    logo: string
+    readMe: string
+    stylesheet: string
+  }
 }
 export interface DeployConfig {
   deployServicePack: boolean


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/551

## Intent

Add `doxyContent` attribute to `docConfig`

```
  doxyContent?: {
    favIcon: string
    footer: string
    header: string
    layout: string
    logo: string
    readMe: string
    stylesheet: string
  }
```
## Implementation

updated `config.ts`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
