### PR TITLE
fix(docs): added path to docConfig

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,13 +18,14 @@ export interface DocConfig {
   outDirectory?: string
   dataControllerUrl?: string
   doxyContent?: {
-    favIcon: string
-    footer: string
-    header: string
-    layout: string
-    logo: string
-    readMe: string
-    stylesheet: string
+    favIcon?: string
+    footer?: string
+    header?: string
+    layout?: string
+    logo?: string
+    readMe?: string
+    stylesheet?: string
+    path?: string
   }
 }
 export interface DeployConfig {


### PR DESCRIPTION
## Intent

Make doxygen content folder's path customizable

## Implementation

Added `path` to `docConfig.doxyContent`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
