### PR TITLE
feat(buildConfig): sasjsresults folder added

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,7 +5,8 @@ export interface Config {
 }
 export interface BuildConfig extends Config {
   buildOutputFileName: string
-  buildOutputFolder: string
+  buildOutputFolder?: string
+  buildResultsFolder?: string
 }
 export interface ServiceConfig extends Config {
   serviceFolders: string[]

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -306,6 +306,7 @@ describe('Target', () => {
       termProgram: '',
       buildOutputFileName: `${target.name}.sas`,
       buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
       macroVars: {}
     })
     expect(json.jobConfig).toEqual({

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -217,6 +217,7 @@ export class Target implements TargetJson {
         termProgram: '',
         buildOutputFileName: `${this.name}.sas`,
         buildOutputFolder: 'sasjsbuild',
+        buildResultsFolder: 'sasjsresults',
         macroVars: {}
       },
       jobConfig: this.jobConfig || {

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -204,6 +204,7 @@ describe('validateBuildConfig', () => {
     expect(validateBuildConfig(({} as unknown) as BuildConfig, 'test')).toEqual(
       {
         buildOutputFolder: 'sasjsbuild',
+        buildResultsFolder: 'sasjsresults',
         buildOutputFileName: 'test.sas',
         initProgram: '',
         termProgram: '',
@@ -217,6 +218,7 @@ describe('validateBuildConfig', () => {
       validateBuildConfig(
         ({
           buildOutputFolder: 'sasjsbuild',
+          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'test.sas',
           initProgram: null
         } as unknown) as BuildConfig,
@@ -224,6 +226,7 @@ describe('validateBuildConfig', () => {
       )
     ).toEqual({
       buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'test.sas',
       initProgram: '',
       termProgram: '',
@@ -236,6 +239,7 @@ describe('validateBuildConfig', () => {
       validateBuildConfig(
         ({
           buildOutputFolder: 'sasjsbuild',
+          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'output.sas',
           initProgram: 'test',
           termProgram: null
@@ -244,6 +248,7 @@ describe('validateBuildConfig', () => {
       )
     ).toEqual({
       buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'output.sas',
       initProgram: 'test',
       termProgram: '',
@@ -256,6 +261,7 @@ describe('validateBuildConfig', () => {
       validateBuildConfig(
         {
           buildOutputFolder: 'sasjsbuild',
+          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'output.sas',
           initProgram: 'test',
           termProgram: 'test',
@@ -265,6 +271,7 @@ describe('validateBuildConfig', () => {
       )
     ).toEqual({
       buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'output.sas',
       initProgram: 'test',
       termProgram: 'test',
@@ -277,6 +284,7 @@ describe('validateBuildConfig', () => {
       validateBuildConfig(
         ({
           buildOutputFolder: 'sasjsbuild',
+          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'test',
           initProgram: 'test',
           termProgram: 'test'
@@ -285,6 +293,7 @@ describe('validateBuildConfig', () => {
       )
     ).toEqual({
       buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'test',
       initProgram: 'test',
       termProgram: 'test',

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -145,6 +145,10 @@ export const validateBuildConfig = (
   if (!buildConfig) {
     throw new Error('Invalid build config: JSON cannot be null or undefined.')
   }
+  if (!buildConfig.buildResultsFolder) {
+    buildConfig.buildResultsFolder = 'sasjsresults'
+  }
+
   if (!buildConfig.buildOutputFolder) {
     buildConfig.buildOutputFolder = 'sasjsbuild'
   }


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/569

## Intent

Resutls folder should be configurable.

## Implementation

`buildResultsFolder` added to `buildConfig`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
