### PR TITLE
feat(file): add function that lists subfolders

### DIFF
--- a/src/file/file.spec.ts
+++ b/src/file/file.spec.ts
@@ -7,7 +7,9 @@ import {
   deleteFolder,
   unifyFilePath,
   getRelativePath,
-  listFilesInFolder
+  listFilesInFolder,
+  createFolder,
+  listSubFoldersInFolder
 } from './file'
 
 describe('createFile', () => {
@@ -93,6 +95,23 @@ describe('listFilesInFolder', () => {
     ).resolves.toEqual([filename])
 
     await deleteFile(filePath)
+  })
+})
+
+describe('listSubFoldersInFolder', () => {
+  const timestamp = new Date().valueOf()
+  const folderName = `test-create-folder-${timestamp}`
+
+  it('should return a list of folders at the given path', async () => {
+    const folderPath = path.join(__dirname, folderName)
+
+    await createFolder(folderPath)
+
+    await expect(listSubFoldersInFolder(__dirname)).resolves.toEqual([
+      folderName
+    ])
+
+    await deleteFolder(folderPath)
   })
 })
 

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -25,6 +25,14 @@ export async function listFilesInFolder(folderName: string): Promise<string[]> {
     .then((list) => list.filter((f) => !f.isDirectory()).map((f) => f.name))
 }
 
+export async function listSubFoldersInFolder(
+  folderName: string
+): Promise<string[]> {
+  return fs.promises
+    .readdir(folderName, { withFileTypes: true })
+    .then((list) => list.filter((f) => f.isDirectory()).map((f) => f.name))
+}
+
 export async function createFolder(folderName: string): Promise<string> {
   return fs.promises.mkdir(folderName, { recursive: true })
 }


### PR DESCRIPTION
## Issue

Required for https://github.com/sasjs/lint/issues/1.

## Intent

Add the ability to list subfolders in a given folder path.

## Implementation

* Added `listSubFoldersInFolder` function.
* Added test.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
