### PR TITLE
fix(prompt): fixed prompt types dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,12 +50,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.0.tgz",
-      "integrity": "sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
+      "integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.0",
+        "@babel/types": "^7.14.1",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -266,9 +266,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.0.tgz",
-      "integrity": "sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -407,9 +407,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.0.tgz",
-      "integrity": "sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.0",
@@ -754,8 +754,7 @@
     "@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
-      "dev": true
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -773,7 +772,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.11.tgz",
       "integrity": "sha512-dcF5L3rU9VfpLEJIV++FEyhGhuIpJllNEwllVuJ5g8eoVqjf048tW9+spivIwjzgPbtaGAl7mIZW3cmhDAq2UQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -812,9 +810,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.2.tgz",
-      "integrity": "sha512-VrMS8kxT0e7J1EX0p6rI/E0FbfOVcvBpbIqHThFv+f8YrZIlMfVotYcXKVPmTvPW8sW5miJzfUFrrvthUZg8VQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.3.tgz",
+      "integrity": "sha512-IJ3kohgrCGAVZrTAc2ufb2Hk2IAdkZTrMHo9DYDC5hX41HrcavlIL0nx31NQLdSkgAk8yE7oFSwPVYX17HWNHw==",
       "dev": true
     },
     "acorn-globals": {
@@ -1211,9 +1209,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001220",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001220.tgz",
-      "integrity": "sha512-pjC2T4DIDyGAKTL4dMvGUQaMUHRmhvPpAgNNTa14jaBWHu+bLQgvpFqElxh9L4829Fdx0PlKiMp3wnYldRtECA==",
+      "version": "1.0.30001221",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001221.tgz",
+      "integrity": "sha512-b9TOZfND3uGSLjMOrLh8XxSQ41x8mX+9MLJYDM4AAHLfaZHttrLNPrScWjVnBITRZbY5sPpCt7X85n7VSLZ+/g==",
       "dev": true
     },
     "capture-exit": {
@@ -1583,9 +1581,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.725",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.725.tgz",
-      "integrity": "sha512-2BbeAESz7kc6KBzs7WVrMc1BY5waUphk4D4DX5dSQXJhsc3tP5ZFaiyuL0AB7vUKzDYpIeYwTYlEfxyjsGUrhw==",
+      "version": "1.3.726",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.726.tgz",
+      "integrity": "sha512-dw7WmrSu/JwtACiBzth8cuKf62NKL1xVJuNvyOg0jvruN/n4NLtGYoTzciQquCPNaS2eR+BT5GrxHbslfc/w1w==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@types/cli-table": "^0.3.0",
     "@types/jest": "^26.0.15",
-    "@types/prompts": "^2.0.11",
     "@types/valid-url": "^1.0.3",
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
@@ -45,6 +44,7 @@
     "cli-table": "^0.3.6",
     "consola": "^2.15.0",
     "prompts": "^2.4.1",
+    "@types/prompts": "^2.0.11",
     "valid-url": "^1.0.9"
   }
 }


### PR DESCRIPTION
## Intent

Fix `readAndValidateInput` utility.

## Implementation

Moved `@types/prompts` from `devDependencies` to `dependencies`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/116992752-32820b80-acdf-11eb-9152-b613a5957ef2.png)
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
