### PR TITLE
feat(git): enabled git hook enforcing conventional commits

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -1,0 +1,18 @@
+#!/bin/sh
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+
+# Get the commit message (the parameter we're given is just the path to the
+# temporary file which holds the message).
+commit_message=$(cat "$1")
+
+if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z \-]+\))?!?: .+$") then
+   echo "${GREEN} ✔ Commit message meets Conventional Commit standards"
+   exit 0
+fi
+
+echo "${RED}❌ Commit message does not meet the Conventional Commit standard!"
+echo "An example of a valid message is:"
+echo "  feat(login): add the 'remember me' button"
+echo "ℹ More details at: https://www.conventionalcommits.org/en/v1.0.0/#summary"
+exit 1

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "package:lib": "npm run build && cp ./package.json build && cp README.md build && cd build && npm version \"5.0.0\" && npm pack",
     "test": "jest --coverage",
     "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'"
+    "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
+    "postinstall": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
   },
   "repository": {
     "type": "git",

--- a/src/input/validators.spec.ts
+++ b/src/input/validators.spec.ts
@@ -34,7 +34,7 @@ describe('urlValidator', () => {
   it('should return an error message when the URL is null', () => {
     const url = null
 
-    expect(urlValidator((url as unknown) as string, errorMessage)).toEqual(
+    expect(urlValidator(url as unknown as string, errorMessage)).toEqual(
       errorMessage
     )
   })
@@ -42,7 +42,7 @@ describe('urlValidator', () => {
   it('should return an error message when the URL is undefined', () => {
     const url = undefined
 
-    expect(urlValidator((url as unknown) as string, errorMessage)).toEqual(
+    expect(urlValidator(url as unknown as string, errorMessage)).toEqual(
       errorMessage
     )
   })

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -30,14 +30,14 @@ import {
 
 describe('validateTargetName', () => {
   it('should throw an error with null target name', () => {
-    expect(() => validateTargetName((null as unknown) as string)).toThrowError(
+    expect(() => validateTargetName(null as unknown as string)).toThrowError(
       'Invalid target name: `name` cannot be empty, null or undefined.'
     )
   })
 
   it('should throw an error with undefined target name', () => {
     expect(() =>
-      validateTargetName((undefined as unknown) as string)
+      validateTargetName(undefined as unknown as string)
     ).toThrowError(
       'Invalid target name: `name` cannot be empty, null or undefined.'
     )
@@ -67,7 +67,7 @@ describe('validateTargetName', () => {
 describe('validateServerType', () => {
   it('should throw an error when server type is null', () => {
     expect(() =>
-      validateServerType((null as unknown) as ServerType)
+      validateServerType(null as unknown as ServerType)
     ).toThrowError(
       'Invalid server type: `serverType` cannot be null or undefined.'
     )
@@ -75,7 +75,7 @@ describe('validateServerType', () => {
 
   it('should throw an error when server type is undefined', () => {
     expect(() =>
-      validateServerType((undefined as unknown) as ServerType)
+      validateServerType(undefined as unknown as ServerType)
     ).toThrowError(
       'Invalid server type: `serverType` cannot be null or undefined.'
     )
@@ -83,7 +83,7 @@ describe('validateServerType', () => {
 
   it('should throw an error when server type is not SAS9 or SASViya', () => {
     expect(() =>
-      validateServerType(('garbage' as unknown) as ServerType)
+      validateServerType('garbage' as unknown as ServerType)
     ).toThrowError(
       `Invalid server type: Supported values for  \`serverType\` are ${ServerType.SasViya} and ${ServerType.Sas9}.`
     )
@@ -100,13 +100,13 @@ describe('validateServerType', () => {
 
 describe('validateAppLoc', () => {
   it('should throw an error when appLoc is null', () => {
-    expect(() => validateAppLoc((null as unknown) as string)).toThrowError(
+    expect(() => validateAppLoc(null as unknown as string)).toThrowError(
       'Invalid app location: `appLoc` cannot be empty, null or undefined.'
     )
   })
 
   it('should throw an error when appLoc is undefined', () => {
-    expect(() => validateAppLoc((undefined as unknown) as string)).toThrowError(
+    expect(() => validateAppLoc(undefined as unknown as string)).toThrowError(
       'Invalid app location: `appLoc` cannot be empty, null or undefined.'
     )
   })
@@ -130,11 +130,11 @@ describe('validateAppLoc', () => {
 
 describe('validateServerUrl', () => {
   it('should set server URL to the empty string when it is null', () => {
-    expect(validateServerUrl((null as unknown) as string)).toEqual('')
+    expect(validateServerUrl(null as unknown as string)).toEqual('')
   })
 
   it('should set server URL to the empty string when it is undefined', () => {
-    expect(validateServerUrl((undefined as unknown) as string)).toEqual('')
+    expect(validateServerUrl(undefined as unknown as string)).toEqual('')
   })
 
   it('should throw an error when server URL is not a valid URL', () => {
@@ -156,25 +156,25 @@ describe('validateServerUrl', () => {
 
 describe('validateAllowInsecureRequests', () => {
   it('should set allowInsecureRequests to false when it is null', () => {
-    expect(validateAllowInsecureRequests((null as unknown) as boolean)).toEqual(
+    expect(validateAllowInsecureRequests(null as unknown as boolean)).toEqual(
       false
     )
   })
 
   it('should set allowInsecureRequests to false when it is undefined', () => {
     expect(
-      validateAllowInsecureRequests((undefined as unknown) as boolean)
+      validateAllowInsecureRequests(undefined as unknown as boolean)
     ).toEqual(false)
   })
 
   it('should throw an error when allowInsecureRequests is not a boolean', () => {
     expect(() =>
-      validateAllowInsecureRequests(('some-string' as unknown) as boolean)
+      validateAllowInsecureRequests('some-string' as unknown as boolean)
     ).toThrowError(
       'Invalid value: `allowInsecureRequests` should either be an empty or a boolean'
     )
     expect(() =>
-      validateAllowInsecureRequests(({} as unknown) as boolean)
+      validateAllowInsecureRequests({} as unknown as boolean)
     ).toThrowError(
       'Invalid value: `allowInsecureRequests` should either be an empty or a boolean'
     )
@@ -192,38 +192,36 @@ describe('validateAllowInsecureRequests', () => {
 describe('validateBuildConfig', () => {
   it('should throw an error when input JSON is null', () => {
     expect(() =>
-      validateBuildConfig((null as unknown) as BuildConfig, 'test')
+      validateBuildConfig(null as unknown as BuildConfig, 'test')
     ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateBuildConfig((undefined as unknown) as BuildConfig, 'test')
+      validateBuildConfig(undefined as unknown as BuildConfig, 'test')
     ).toThrowError('Invalid build config: JSON cannot be null or undefined.')
   })
 
   it('should use the default when build output filename is undefined', () => {
-    expect(validateBuildConfig(({} as unknown) as BuildConfig, 'test')).toEqual(
-      {
-        buildOutputFolder: 'sasjsbuild',
-        buildResultsFolder: 'sasjsresults',
-        buildOutputFileName: 'test.sas',
-        initProgram: '',
-        termProgram: '',
-        macroVars: {}
-      }
-    )
+    expect(validateBuildConfig({} as unknown as BuildConfig, 'test')).toEqual({
+      buildOutputFolder: 'sasjsbuild',
+      buildResultsFolder: 'sasjsresults',
+      buildOutputFileName: 'test.sas',
+      initProgram: '',
+      termProgram: '',
+      macroVars: {}
+    })
   })
 
   it('should set the init program to the empty string if null', () => {
     expect(
       validateBuildConfig(
-        ({
+        {
           buildOutputFolder: 'sasjsbuild',
           buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'test.sas',
           initProgram: null
-        } as unknown) as BuildConfig,
+        } as unknown as BuildConfig,
         'test'
       )
     ).toEqual({
@@ -239,13 +237,13 @@ describe('validateBuildConfig', () => {
   it('should set the term program to the empty string if null', () => {
     expect(
       validateBuildConfig(
-        ({
+        {
           buildOutputFolder: 'sasjsbuild',
           buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'output.sas',
           initProgram: 'test',
           termProgram: null
-        } as unknown) as BuildConfig,
+        } as unknown as BuildConfig,
         'test'
       )
     ).toEqual({
@@ -284,13 +282,13 @@ describe('validateBuildConfig', () => {
   it('should initialise the macro vars if not present', () => {
     expect(
       validateBuildConfig(
-        ({
+        {
           buildOutputFolder: 'sasjsbuild',
           buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'test',
           initProgram: 'test',
           termProgram: 'test'
-        } as unknown) as BuildConfig,
+        } as unknown as BuildConfig,
         'test'
       )
     ).toEqual({
@@ -307,22 +305,22 @@ describe('validateBuildConfig', () => {
 describe('validateDeployConfig', () => {
   it('should throw an error when deployConfig is null', () => {
     expect(() =>
-      validateDeployConfig((null as unknown) as DeployConfig)
+      validateDeployConfig(null as unknown as DeployConfig)
     ).toThrowError('Invalid deploy config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when deployConfig is undefined', () => {
     expect(() =>
-      validateDeployConfig((undefined as unknown) as DeployConfig)
+      validateDeployConfig(undefined as unknown as DeployConfig)
     ).toThrowError('Invalid deploy config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when deployServicePack is non-boolean', () => {
     expect(
-      validateDeployConfig(({
+      validateDeployConfig({
         deployServicePack: 'test',
         deployScripts: []
-      } as unknown) as DeployConfig)
+      } as unknown as DeployConfig)
     ).toEqual({
       deployServicePack: true,
       deployScripts: []
@@ -343,9 +341,9 @@ describe('validateDeployConfig', () => {
 
   it('should initialise deployScripts when not initialised', () => {
     expect(
-      validateDeployConfig(({
+      validateDeployConfig({
         deployServicePack: true
-      } as unknown) as DeployConfig)
+      } as unknown as DeployConfig)
     ).toEqual({
       deployServicePack: true,
       deployScripts: []
@@ -356,22 +354,22 @@ describe('validateDeployConfig', () => {
 describe('validateServiceConfig', () => {
   it('should throw an error when input JSON is null', () => {
     expect(() =>
-      validateServiceConfig((null as unknown) as ServiceConfig)
+      validateServiceConfig(null as unknown as ServiceConfig)
     ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateServiceConfig((undefined as unknown) as ServiceConfig)
+      validateServiceConfig(undefined as unknown as ServiceConfig)
     ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
   })
 
   it('should set the init program to the empty string if null', () => {
     expect(
-      validateServiceConfig(({
+      validateServiceConfig({
         serviceFolders: [],
         initProgram: null
-      } as unknown) as ServiceConfig)
+      } as unknown as ServiceConfig)
     ).toEqual({
       serviceFolders: [],
       initProgram: '',
@@ -382,11 +380,11 @@ describe('validateServiceConfig', () => {
 
   it('should set the term program to the empty string if null', () => {
     expect(
-      validateServiceConfig(({
+      validateServiceConfig({
         serviceFolders: [],
         initProgram: 'test',
         termProgram: ''
-      } as unknown) as ServiceConfig)
+      } as unknown as ServiceConfig)
     ).toEqual({
       serviceFolders: [],
       initProgram: 'test',
@@ -413,10 +411,10 @@ describe('validateServiceConfig', () => {
 
   it('should initialise the macro vars if not present', () => {
     expect(
-      validateServiceConfig(({
+      validateServiceConfig({
         initProgram: 'init',
         termProgram: 'term'
-      } as unknown) as ServiceConfig)
+      } as unknown as ServiceConfig)
     ).toEqual({
       serviceFolders: [],
       initProgram: 'init',
@@ -428,23 +426,23 @@ describe('validateServiceConfig', () => {
 
 describe('validateJobConfig', () => {
   it('should throw an error when input JSON is null', () => {
-    expect(() =>
-      validateJobConfig((null as unknown) as JobConfig)
-    ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
+    expect(() => validateJobConfig(null as unknown as JobConfig)).toThrowError(
+      'Invalid job config: JSON cannot be null or undefined.'
+    )
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateJobConfig((undefined as unknown) as JobConfig)
+      validateJobConfig(undefined as unknown as JobConfig)
     ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
   })
 
   it('should set the init program to the empty string if null', () => {
     expect(
-      validateJobConfig(({
+      validateJobConfig({
         jobFolders: [],
         initProgram: null
-      } as unknown) as JobConfig)
+      } as unknown as JobConfig)
     ).toEqual({
       jobFolders: [],
       initProgram: '',
@@ -455,11 +453,11 @@ describe('validateJobConfig', () => {
 
   it('should set the term program to the empty string if null', () => {
     expect(
-      validateJobConfig(({
+      validateJobConfig({
         jobFolders: [],
         initProgram: 'test',
         termProgram: ''
-      } as unknown) as JobConfig)
+      } as unknown as JobConfig)
     ).toEqual({
       jobFolders: [],
       initProgram: 'test',
@@ -486,10 +484,10 @@ describe('validateJobConfig', () => {
 
   it('should initialise the macro vars if not present', () => {
     expect(
-      validateJobConfig(({
+      validateJobConfig({
         initProgram: 'init',
         termProgram: 'term'
-      } as unknown) as JobConfig)
+      } as unknown as JobConfig)
     ).toEqual({
       jobFolders: [],
       initProgram: 'init',
@@ -502,19 +500,19 @@ describe('validateJobConfig', () => {
 describe('validateStreamConfig', () => {
   it('should throw an error when input JSON is null', () => {
     expect(() =>
-      validateStreamConfig((null as unknown) as StreamConfig)
+      validateStreamConfig(null as unknown as StreamConfig)
     ).toThrowError('Invalid stream config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateStreamConfig((undefined as unknown) as StreamConfig)
+      validateStreamConfig(undefined as unknown as StreamConfig)
     ).toThrowError('Invalid stream config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when streamWeb is a non-boolean value', () => {
     expect(() =>
-      validateStreamConfig(({ streamWeb: 'foo' } as unknown) as StreamConfig)
+      validateStreamConfig({ streamWeb: 'foo' } as unknown as StreamConfig)
     ).toThrowError(
       'Invalid stream config: `streamWeb` cannot be a non-boolean value.'
     )
@@ -522,10 +520,10 @@ describe('validateStreamConfig', () => {
 
   it('should throw an error when streamWeb is true and a streamWebFolder is not specified', () => {
     expect(() =>
-      validateStreamConfig(({
+      validateStreamConfig({
         streamWeb: true,
         streamWebFolder: ''
-      } as unknown) as StreamConfig)
+      } as unknown as StreamConfig)
     ).toThrowError(
       'Invalid stream config: `streamWebFolder` cannot be empty, null or undefined when `streamWeb` is true.'
     )
@@ -533,11 +531,11 @@ describe('validateStreamConfig', () => {
 
   it('should throw an error when webSourcePath is empty', () => {
     expect(() =>
-      validateStreamConfig(({
+      validateStreamConfig({
         streamWeb: true,
         streamWebFolder: '.',
         webSourcePath: ''
-      } as unknown) as StreamConfig)
+      } as unknown as StreamConfig)
     ).toThrowError(
       'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
     )
@@ -545,11 +543,11 @@ describe('validateStreamConfig', () => {
 
   it('should throw an error when webSourcePath is null', () => {
     expect(() =>
-      validateStreamConfig(({
+      validateStreamConfig({
         streamWeb: true,
         streamWebFolder: '.',
         webSourcePath: null
-      } as unknown) as StreamConfig)
+      } as unknown as StreamConfig)
     ).toThrowError(
       'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
     )
@@ -557,11 +555,11 @@ describe('validateStreamConfig', () => {
 
   it('should throw an error when webSourcePath is undefined', () => {
     expect(() =>
-      validateStreamConfig(({
+      validateStreamConfig({
         streamWeb: true,
         streamWebFolder: '.',
         webSourcePath: undefined
-      } as unknown) as StreamConfig)
+      } as unknown as StreamConfig)
     ).toThrowError(
       'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
     )
@@ -605,11 +603,11 @@ describe('validateStreamConfig', () => {
 
   it('should initialise the stream service name if not set', () => {
     expect(
-      validateStreamConfig(({
+      validateStreamConfig({
         streamWeb: true,
         streamWebFolder: '.',
         webSourcePath: '.'
-      } as unknown) as StreamConfig)
+      } as unknown as StreamConfig)
     ).toEqual({
       streamWeb: true,
       streamWebFolder: '.',
@@ -661,7 +659,7 @@ describe('validateRepositoryName', () => {
 describe('validateAuthConfig', () => {
   it('should throw an error when authConfig is null', () => {
     expect(() =>
-      validateAuthConfig((null as unknown) as AuthConfig)
+      validateAuthConfig(null as unknown as AuthConfig)
     ).toThrowError('Invalid auth config: JSON cannot be null or undefined.')
   })
 
@@ -684,10 +682,10 @@ describe('validateAuthConfig', () => {
 
 describe('validateDocConfig', () => {
   it('should return the doc config when null/undefined', () => {
-    expect(validateDocConfig((null as unknown) as DocConfig)).toMatchObject({})
-    expect(
-      validateDocConfig((undefined as unknown) as DocConfig)
-    ).toMatchObject({})
+    expect(validateDocConfig(null as unknown as DocConfig)).toMatchObject({})
+    expect(validateDocConfig(undefined as unknown as DocConfig)).toMatchObject(
+      {}
+    )
     expect(validateDocConfig({} as DocConfig)).toMatchObject({})
   })
 
@@ -731,7 +729,7 @@ describe('validateDocConfig', () => {
   it('should set dataControllerUrl to undefined when it is null/undefined', () => {
     expect(
       validateDocConfig({
-        dataControllerUrl: (null as unknown) as string
+        dataControllerUrl: null as unknown as string
       })
     ).toEqual({
       dataControllerUrl: undefined
@@ -779,7 +777,7 @@ describe('validateDocConfig', () => {
   it('should set outDirectory to undefined when it is not string', () => {
     expect(
       validateDocConfig({
-        outDirectory: (null as unknown) as string
+        outDirectory: null as unknown as string
       })
     ).toEqual({
       outDirectory: undefined
@@ -787,7 +785,7 @@ describe('validateDocConfig', () => {
 
     expect(
       validateDocConfig({
-        outDirectory: (false as unknown) as string
+        outDirectory: false as unknown as string
       })
     ).toEqual({
       outDirectory: undefined
@@ -825,8 +823,8 @@ describe('validateDocConfig', () => {
   it('should set displayMacroCore/enableLineage to undefined when it is not boolean', () => {
     expect(
       validateDocConfig({
-        displayMacroCore: (null as unknown) as boolean,
-        enableLineage: (null as unknown) as boolean
+        displayMacroCore: null as unknown as boolean,
+        enableLineage: null as unknown as boolean
       })
     ).toEqual({
       displayMacroCore: undefined,
@@ -870,13 +868,13 @@ describe('validateDocConfig', () => {
 describe('validateTestConfig', () => {
   it('should throw an error when input JSON is null', () => {
     expect(() =>
-      validateTestConfig((null as unknown) as TestConfig)
+      validateTestConfig(null as unknown as TestConfig)
     ).toThrowError('Invalid test config: JSON cannot be null or undefined.')
   })
 
   it('should throw an error when input JSON is undefined', () => {
     expect(() =>
-      validateTestConfig((undefined as unknown) as TestConfig)
+      validateTestConfig(undefined as unknown as TestConfig)
     ).toThrowError('Invalid test config: JSON cannot be null or undefined.')
   })
 
@@ -889,7 +887,7 @@ describe('validateTestConfig', () => {
     testTearDown: ''
   }
   const testAssertion = () =>
-    expect(validateTestConfig((testInput as unknown) as TestConfig)).toEqual(
+    expect(validateTestConfig(testInput as unknown as TestConfig)).toEqual(
       testOutput
     )
 


### PR DESCRIPTION
## Intent

Enable pre-commit git hook enforcing conventional commits.

## Implementation

1. Added `.git-hooks/commit-msg`.
2. Added `postinstall` script to `package.json`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/118924884-60ee2080-b946-11eb-8bd1-222248155c8d.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
