### PR TITLE
feat: added urlOrigin utility

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
 export { asyncForEach, uuidv4 } from './utils'
+
+export { urlOrigin } from './url'

--- a/src/utils/url.spec.ts
+++ b/src/utils/url.spec.ts
@@ -1,0 +1,22 @@
+import { urlOrigin } from './url'
+
+describe('urlOrigin', () => {
+  it('should return an empty string if empty string was provided', () => {
+    expect(urlOrigin('')).toEqual('')
+  })
+
+  it('should return url origin', () => {
+    let url = 'https://analytium.co.uk'
+
+    expect(urlOrigin(url)).toEqual(url)
+
+    url += ':8080'
+
+    expect(urlOrigin(url)).toEqual(url)
+    expect(urlOrigin(url + '/test')).toEqual(url)
+  })
+
+  it('should throw an error if provided string is not a valid url', () => {
+    expect(() => urlOrigin('not valid')).toThrow('Invalid URL.')
+  })
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,13 @@
+export const urlOrigin = (str: string) => {
+  if (str === '') return str
+
+  let origin
+
+  try {
+    origin = new URL(str).origin
+  } catch (_) {
+    throw new Error('Invalid URL.')
+  }
+
+  return origin
+}


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/688

## Intent

Create a utility that returns URL origin.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/119152568-18735780-ba59-11eb-9985-5cfb2bfe3243.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/25773492/119152683-3640bc80-ba59-11eb-8381-053cadefec4c.png)
- [x] Reviewer is assigned.
