### PR TITLE
Path sep

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -6,7 +6,7 @@ GREEN="\033[1;32m"
 # temporary file which holds the message).
 commit_message=$(cat "$1")
 
-if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z \-]+\))?!?: .+$") then
+if (echo "$commit_message" | grep -Eq "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9 \-]+\))?!?: .+$") then
    echo "${GREEN} ✔ Commit message meets Conventional Commit standards"
    exit 0
 fi

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -171,3 +171,5 @@ export async function moveFile(
 ): Promise<void> {
   return fs.promises.rename(oldFilePath, newFilePath)
 }
+
+export const pathSepEscaped = path.sep.replace(/\\/g, '\\\\')


### PR DESCRIPTION
## Intent

Create a utility that provides escaped `path.sep` for Windows OS.

## Checks

- [X] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
