### PR TITLE
fix: replaced 'fs' with 'fs-extra'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -708,6 +708,15 @@
       "integrity": "sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
+      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1952,6 +1961,23 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2036,8 +2062,7 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "growly": {
       "version": "1.3.0",
@@ -3067,6 +3092,22 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "jsprim": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,7 +763,8 @@
     "@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -781,6 +782,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.11.tgz",
       "integrity": "sha512-dcF5L3rU9VfpLEJIV++FEyhGhuIpJllNEwllVuJ5g8eoVqjf048tW9+spivIwjzgPbtaGAl7mIZW3cmhDAq2UQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/sasjs/utils#readme",
   "devDependencies": {
     "@types/cli-table": "^0.3.0",
+    "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.15",
     "@types/valid-url": "^1.0.3",
     "jest": "^26.6.3",
@@ -41,11 +42,12 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
+    "@types/prompts": "^2.0.11",
     "chalk": "^4.1.1",
     "cli-table": "^0.3.6",
     "consola": "^2.15.0",
+    "fs-extra": "^10.0.0",
     "prompts": "^2.4.1",
-    "@types/prompts": "^2.0.11",
     "valid-url": "^1.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/cli-table": "^0.3.0",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.15",
+    "@types/prompts": "^2.0.11",
     "@types/valid-url": "^1.0.3",
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
@@ -42,7 +43,6 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@types/prompts": "^2.0.11",
     "chalk": "^4.1.1",
     "cli-table": "^0.3.6",
     "consola": "^2.15.0",

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import { asyncForEach } from '../utils'
 


### PR DESCRIPTION
## Intent

Remove `fs` package

> This package name is not currently in use, but was formerly occupied by another package. To avoid malicious use, npm is hanging on to the package name, but loosely, and we'll probably give it to you if you want it.

What this PR intends to achieve.

## Implementation

Replaced `fs` with `fs-extra`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
