### PR TITLE
fix: added 'pathSepEscaped' to export list

### DIFF
--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -12,6 +12,7 @@ export {
   getRelativePath,
   unifyFilePath,
   moveFile,
+  pathSepEscaped,
   copy,
   base64EncodeImageFile,
   base64EncodeFile


### PR DESCRIPTION
## Implementation

Added `pathSepEscaped` to exported list

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
