### PR TITLE
fix: moved 'getRealPath' from sasjs/cli

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -193,3 +193,7 @@ export async function base64EncodeImageFile(filePath: string) {
 export async function base64EncodeFile(filePath: string) {
   return fs.promises.readFile(filePath, { encoding: 'base64' })
 }
+
+export function getRealPath(file: string) {
+  return fs.realpathSync(file)
+}

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -15,5 +15,6 @@ export {
   pathSepEscaped,
   copy,
   base64EncodeImageFile,
-  base64EncodeFile
+  base64EncodeFile,
+  getRealPath
 } from './file'


### PR DESCRIPTION
## Implementation

Moved `getRealPath` from `sasjs/cli` to `utils/file`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
