### PR TITLE
feat(token-expiry): add utils to check for token expiry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2942,6 +2942,11 @@
         "universalify": "^2.0.0"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cli-table": "^0.3.6",
     "consola": "^2.15.0",
     "fs-extra": "^10.0.0",
+    "jwt-decode": "^3.1.2",
     "prompts": "^2.4.1",
     "valid-url": "^1.0.9"
   }

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -1,0 +1,55 @@
+import { isAccessTokenExpiring, isRefreshTokenExpiring } from './auth'
+
+describe('isAccessTokenExpiring', () => {
+  it('should return true if the token is expiring in an hour', () => {
+    const token = generateToken(3600)
+    expect(isAccessTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return true if the token is expiring in less than an hour', () => {
+    const token = generateToken(600)
+    expect(isAccessTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return true if the token is not provided', () => {
+    const token = undefined
+    expect(isAccessTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return false if the token is not expiring within an hour', () => {
+    const token = generateToken(7200)
+    expect(isAccessTokenExpiring(token)).toBeFalsy()
+  })
+})
+
+describe('isRefreshTokenExpiring', () => {
+  it('should return true if the token is expiring in 30 seconds', () => {
+    const token = generateToken(30)
+    expect(isRefreshTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return true if the token is expiring in less than 30 seconds', () => {
+    const token = generateToken(10)
+    expect(isRefreshTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return true if the token is not provided', () => {
+    const token = undefined
+    expect(isRefreshTokenExpiring(token)).toBeTruthy()
+  })
+
+  it('should return false if the token is not expiring within 30 seconds', () => {
+    const token = generateToken(120)
+    expect(isRefreshTokenExpiring(token)).toBeFalsy()
+  })
+})
+
+const generateToken = (timeToLiveSeconds: number): string => {
+  const exp =
+    new Date(new Date().getTime() + timeToLiveSeconds * 1000).getTime() / 1000
+  const header = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9'
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64')
+  const signature = '4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo'
+  const token = `${header}.${payload}.${signature}`
+  return token
+}

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -20,6 +20,16 @@ describe('isAccessTokenExpiring', () => {
     const token = generateToken(7200)
     expect(isAccessTokenExpiring(token)).toBeFalsy()
   })
+
+  it('should return true if the token is expiring within the given time', () => {
+    const token = generateToken(7200)
+    expect(isAccessTokenExpiring(token, 8000)).toBeTruthy()
+  })
+
+  it('should return false if the token is not expiring within the given time', () => {
+    const token = generateToken(120)
+    expect(isAccessTokenExpiring(token, 60)).toBeFalsy()
+  })
 })
 
 describe('isRefreshTokenExpiring', () => {
@@ -41,6 +51,16 @@ describe('isRefreshTokenExpiring', () => {
   it('should return false if the token is not expiring within 30 seconds', () => {
     const token = generateToken(120)
     expect(isRefreshTokenExpiring(token)).toBeFalsy()
+  })
+
+  it('should return true if the token is expiring within the given time', () => {
+    const token = generateToken(7200)
+    expect(isRefreshTokenExpiring(token, 8000)).toBeTruthy()
+  })
+
+  it('should return false if the token is not expiring within the given time', () => {
+    const token = generateToken(120)
+    expect(isRefreshTokenExpiring(token, 60)).toBeFalsy()
   })
 })
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -6,15 +6,17 @@ import jwtDecode from 'jwt-decode'
  * Access Token. In the case that the Refresh Token is expired, 1 hour is enough to let
  * most jobs finish.
  * @param {string} token- token string that will be evaluated
+ * @param {number} timeToLiveSeconds - the amount of time that the token has before it expires, defaults to 3600
+ * @returns {boolean} a value indicating whether the token is about to expire
  */
-export function isAccessTokenExpiring(token?: string): boolean {
+export function isAccessTokenExpiring(
+  token?: string,
+  timeToLiveSeconds = 3600
+): boolean {
   if (!token) {
     return true
   }
-  const payload = jwtDecode<{ exp: number }>(token)
-  const timeToLive = payload.exp - new Date().valueOf() / 1000
-
-  return timeToLive <= 60 * 60 // 1 hour
+  return isTokenExpiring(token, timeToLiveSeconds)
 }
 
 /**
@@ -23,13 +25,22 @@ export function isAccessTokenExpiring(token?: string): boolean {
  * credentials in a browser to obtain an authorisation code). 30 seconds is enough time
  * to make a request for a final Access Token.
  * @param {string} token- token string that will be evaluated
+ * @param {number} timeToLiveSeconds - the amount of time that the token has before it expires, defaults to 30
+ * @returns {boolean} a value indicating whether the token is about to expire
  */
-export function isRefreshTokenExpiring(token?: string): boolean {
+export function isRefreshTokenExpiring(
+  token?: string,
+  timeToLiveSeconds = 30
+): boolean {
   if (!token) {
     return true
   }
+  return isTokenExpiring(token, timeToLiveSeconds)
+}
+
+function isTokenExpiring(token: string, timeToLiveSeconds: number) {
   const payload = jwtDecode<{ exp: number }>(token)
   const timeToLive = payload.exp - new Date().valueOf() / 1000
 
-  return timeToLive <= 30 // 30 seconds
+  return timeToLive <= timeToLiveSeconds
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,0 +1,35 @@
+import jwtDecode from 'jwt-decode'
+
+/**
+ * Checks if the Access Token is expired or is expiring in 1 hour.  A default Access Token
+ * lasts 12 hours. If the Access Token expires, the Refresh Token is used to fetch a new
+ * Access Token. In the case that the Refresh Token is expired, 1 hour is enough to let
+ * most jobs finish.
+ * @param {string} token- token string that will be evaluated
+ */
+export function isAccessTokenExpiring(token?: string): boolean {
+  if (!token) {
+    return true
+  }
+  const payload = jwtDecode<{ exp: number }>(token)
+  const timeToLive = payload.exp - new Date().valueOf() / 1000
+
+  return timeToLive <= 60 * 60 // 1 hour
+}
+
+/**
+ * Checks if the Refresh Token is expired or expiring in 30 secs. A default Refresh Token
+ * lasts 30 days.  Once the Refresh Token expires, the user must re-authenticate (provide
+ * credentials in a browser to obtain an authorisation code). 30 seconds is enough time
+ * to make a request for a final Access Token.
+ * @param {string} token- token string that will be evaluated
+ */
+export function isRefreshTokenExpiring(token?: string): boolean {
+  if (!token) {
+    return true
+  }
+  const payload = jwtDecode<{ exp: number }>(token)
+  const timeToLive = payload.exp - new Date().valueOf() / 1000
+
+  return timeToLive <= 30 // 30 seconds
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './auth'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './auth'
 export * from './file'
 export * from './formatter'
 export * from './input'


### PR DESCRIPTION
## Issue

https://github.com/sasjs/adapter/issues/444

## Intent

Add functions to check for expiry of access and refresh tokens.

## Implementation

* Added `auth` utils.
* Added unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`). - The CLI does not depend on this right now. I will test the CLI with the new version of the adapter after this is merged.
- [x] Reviewer is assigned.
