### PR TITLE
feat: add auth config for sas9 in target

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -50,7 +50,7 @@ export interface AuthConfig {
   secret: string
 }
 
-export interface AuthConfigForSas9 {
+export interface AuthConfigSas9 {
   userName: string
   password: string
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -50,6 +50,11 @@ export interface AuthConfig {
   secret: string
 }
 
+export interface AuthConfigForSas9 {
+  userName: string
+  password: string
+}
+
 export interface TestConfig {
   initProgram: string
   termProgram: string

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -310,6 +310,29 @@ describe('Target', () => {
     expect(target.authConfig).toEqual(authConfig)
   })
 
+  it('should create an instance with the auth config for sas9 when available', () => {
+    const authConfigForSas9 = {
+      userName: 'TestUser',
+      password: 'hello-world'
+    }
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      authConfigForSas9
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.authConfigForSas9).toEqual(authConfigForSas9)
+  })
+
+  //224,234,246,256,266,277,285
   it('should convert to JSON with minimal attributes', () => {
     const target = new Target({
       name: 'test',
@@ -390,6 +413,40 @@ describe('Target', () => {
     expect(json.serviceConfig).toEqual(undefined)
     expect(json.streamConfig).toEqual(undefined)
     expect(json.deployConfig).toEqual(undefined)
+  })
+
+  it('should convert to JSON with authConfig is equal to this.authConfig', () => {
+    const authConfig = {
+      access_token: 'T35T',
+      refresh_token: 'R3FR35H',
+      client: 'CL13NT',
+      secret: '53CR3T'
+    }
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      authConfig
+    })
+    const json = target.toJson()
+    expect(target.authConfig).toEqual(authConfig)
+  })
+
+  it('should convert to JSON with authConfigForSas9 is equal to this.authConfigForSas9', () => {
+    const authConfigForSas9 = {
+      userName: 'TestUser',
+      password: 'Hello-World'
+    }
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      authConfigForSas9
+    })
+    const json = target.toJson()
+    expect(target.authConfigForSas9).toEqual(authConfigForSas9)
   })
 
   it('should include context name in JSON when server type is SASVIYA', () => {

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -311,7 +311,7 @@ describe('Target', () => {
   })
 
   it('should create an instance with the auth config for sas9 when available', () => {
-    const authConfigForSas9 = {
+    const authConfigSas9 = {
       userName: 'TestUser',
       password: 'hello-world'
     }
@@ -320,19 +320,12 @@ describe('Target', () => {
       serverUrl: '',
       serverType: ServerType.Sas9,
       appLoc: '/test',
-      authConfigForSas9
+      authConfigSas9
     })
 
-    expect(target).toBeTruthy()
-    expect(target instanceof Target).toEqual(true)
-    expect(target.name).toEqual('test')
-    expect(target.serverUrl).toEqual('')
-    expect(target.serverType).toEqual(ServerType.Sas9)
-    expect(target.appLoc).toEqual('/test')
-    expect(target.authConfigForSas9).toEqual(authConfigForSas9)
+    expect(target.authConfigSas9).toEqual(authConfigSas9)
   })
 
-  //224,234,246,256,266,277,285
   it('should convert to JSON with minimal attributes', () => {
     const target = new Target({
       name: 'test',
@@ -415,7 +408,7 @@ describe('Target', () => {
     expect(json.deployConfig).toEqual(undefined)
   })
 
-  it('should convert to JSON with authConfig is equal to this.authConfig', () => {
+  it('should return a JSON which contains authConfig whose value should be equal to authConfig that was passed in creation of target', () => {
     const authConfig = {
       access_token: 'T35T',
       refresh_token: 'R3FR35H',
@@ -433,8 +426,8 @@ describe('Target', () => {
     expect(target.authConfig).toEqual(authConfig)
   })
 
-  it('should convert to JSON with authConfigForSas9 is equal to this.authConfigForSas9', () => {
-    const authConfigForSas9 = {
+  it('should return a JSON which contains authConfigSas9 whose value should be equal to authConfigSas9 that was passed in creation of target', () => {
+    const authConfigSas9 = {
       userName: 'TestUser',
       password: 'Hello-World'
     }
@@ -443,10 +436,10 @@ describe('Target', () => {
       serverUrl: '',
       serverType: ServerType.Sas9,
       appLoc: '/test',
-      authConfigForSas9
+      authConfigSas9
     })
     const json = target.toJson()
-    expect(target.authConfigForSas9).toEqual(authConfigForSas9)
+    expect(target.authConfigSas9).toEqual(authConfigSas9)
   })
 
   it('should include context name in JSON when server type is SASVIYA', () => {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -1,6 +1,7 @@
 import {
   DocConfig,
   AuthConfig,
+  AuthConfigForSas9,
   BuildConfig,
   DeployConfig,
   ServiceConfig,
@@ -25,6 +26,7 @@ import {
   validateServerName,
   validateRepositoryName,
   validateAuthConfig,
+  validateAuthConfigForSas9,
   validateTestConfig
 } from './targetValidators'
 
@@ -39,6 +41,7 @@ export interface TargetJson {
   appLoc: string
   docConfig?: DocConfig
   authConfig?: AuthConfig
+  authConfigForSas9?: AuthConfigForSas9
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
   serviceConfig?: ServiceConfig
@@ -85,6 +88,11 @@ export class Target implements TargetJson {
     return this._authConfig
   }
   private _authConfig: AuthConfig | undefined
+
+  get authConfigForSas9(): AuthConfigForSas9 | undefined {
+    return this._authConfigForSas9
+  }
+  private _authConfigForSas9: AuthConfigForSas9 | undefined
 
   get buildConfig(): BuildConfig | undefined {
     return this._buildConfig
@@ -172,6 +180,12 @@ export class Target implements TargetJson {
         this._authConfig = validateAuthConfig(json.authConfig)
       }
 
+      if (json.authConfigForSas9) {
+        this._authConfigForSas9 = validateAuthConfigForSas9(
+          json.authConfigForSas9
+        )
+      }
+
       if (json.buildConfig) {
         this._buildConfig = validateBuildConfig(json.buildConfig, this._name)
       }
@@ -228,6 +242,14 @@ export class Target implements TargetJson {
         refresh_token: '',
         client: '',
         secret: ''
+      }
+
+    if (this.authConfigForSas9) {
+      json.authConfigForSas9 = this.authConfigForSas9
+    } else if (withDefaults)
+      json.authConfigForSas9 = {
+        userName: '',
+        password: ''
       }
 
     if (this.buildConfig) {

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -1,7 +1,7 @@
 import {
   DocConfig,
   AuthConfig,
-  AuthConfigForSas9,
+  AuthConfigSas9,
   BuildConfig,
   DeployConfig,
   ServiceConfig,
@@ -26,7 +26,7 @@ import {
   validateServerName,
   validateRepositoryName,
   validateAuthConfig,
-  validateAuthConfigForSas9,
+  validateAuthConfigSas9,
   validateTestConfig
 } from './targetValidators'
 
@@ -41,7 +41,7 @@ export interface TargetJson {
   appLoc: string
   docConfig?: DocConfig
   authConfig?: AuthConfig
-  authConfigForSas9?: AuthConfigForSas9
+  authConfigSas9?: AuthConfigSas9
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
   serviceConfig?: ServiceConfig
@@ -89,10 +89,10 @@ export class Target implements TargetJson {
   }
   private _authConfig: AuthConfig | undefined
 
-  get authConfigForSas9(): AuthConfigForSas9 | undefined {
-    return this._authConfigForSas9
+  get authConfigSas9(): AuthConfigSas9 | undefined {
+    return this._authConfigSas9
   }
-  private _authConfigForSas9: AuthConfigForSas9 | undefined
+  private _authConfigSas9: AuthConfigSas9 | undefined
 
   get buildConfig(): BuildConfig | undefined {
     return this._buildConfig
@@ -180,10 +180,8 @@ export class Target implements TargetJson {
         this._authConfig = validateAuthConfig(json.authConfig)
       }
 
-      if (json.authConfigForSas9) {
-        this._authConfigForSas9 = validateAuthConfigForSas9(
-          json.authConfigForSas9
-        )
+      if (json.authConfigSas9) {
+        this._authConfigSas9 = validateAuthConfigSas9(json.authConfigSas9)
       }
 
       if (json.buildConfig) {
@@ -244,10 +242,10 @@ export class Target implements TargetJson {
         secret: ''
       }
 
-    if (this.authConfigForSas9) {
-      json.authConfigForSas9 = this.authConfigForSas9
+    if (this.authConfigSas9) {
+      json.authConfigSas9 = this.authConfigSas9
     } else if (withDefaults)
-      json.authConfigForSas9 = {
+      json.authConfigSas9 = {
         userName: '',
         password: ''
       }

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -1,7 +1,7 @@
-import { AuthConfigForSas9 } from '.'
 import {
   DocConfig,
   AuthConfig,
+  AuthConfigSas9,
   BuildConfig,
   DeployConfig,
   JobConfig,
@@ -27,7 +27,7 @@ import {
   validateAuthConfig,
   validateDocConfig,
   validateTestConfig,
-  validateAuthConfigForSas9
+  validateAuthConfigSas9
 } from './targetValidators'
 
 describe('validateTargetName', () => {
@@ -667,40 +667,40 @@ describe('validateAuthConfig', () => {
     })
 
     it('should return the auth config when valid', () => {
-      expect(
-        validateAuthConfig({
-          access_token: 'T35T',
-          refresh_token: 'R3FR35H',
-          client: 'CL13NT',
-          secret: '53CR3T'
-        })
-      ).toEqual({
+      const authConfig: AuthConfig = {
         access_token: 'T35T',
         refresh_token: 'R3FR35H',
         client: 'CL13NT',
         secret: '53CR3T'
-      })
+      }
+      expect(validateAuthConfig(authConfig)).toEqual(authConfig)
     })
   })
-  describe('For SAS(', () => {
-    it('should throw an error when authConfigForSas9 is null', () => {
+  describe('For SAS9', () => {
+    it('should throw an error when authConfigSas9 is null', () => {
       expect(() =>
-        validateAuthConfigForSas9(null as unknown as AuthConfigForSas9)
+        validateAuthConfigSas9(null as unknown as AuthConfigSas9)
       ).toThrowError(
         'Invalid auth config for sas9: JSON cannot be null or undefined.'
       )
     })
 
+    it('should throw an error when authConfigSas9 contains empty  userName or password', () => {
+      const authConfigSas9: AuthConfigSas9 = {
+        userName: '',
+        password: ''
+      }
+      expect(() => validateAuthConfigSas9(authConfigSas9)).toThrowError(
+        'Invalid auth config for sas9: userName and password can not be empty'
+      )
+    })
+
     it('should return the auth config for sas9 when valid', () => {
-      expect(
-        validateAuthConfigForSas9({
-          userName: 'TestUser',
-          password: 'TestPassword'
-        })
-      ).toEqual({
+      const authConfigSas9: AuthConfigSas9 = {
         userName: 'TestUser',
         password: 'TestPassword'
-      })
+      }
+      expect(validateAuthConfigSas9(authConfigSas9)).toEqual(authConfigSas9)
     })
   })
 })

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -1,3 +1,4 @@
+import { AuthConfigForSas9 } from '.'
 import {
   DocConfig,
   AuthConfig,
@@ -25,7 +26,8 @@ import {
   validateRepositoryName,
   validateAuthConfig,
   validateDocConfig,
-  validateTestConfig
+  validateTestConfig,
+  validateAuthConfigForSas9
 } from './targetValidators'
 
 describe('validateTargetName', () => {
@@ -657,25 +659,48 @@ describe('validateRepositoryName', () => {
 })
 
 describe('validateAuthConfig', () => {
-  it('should throw an error when authConfig is null', () => {
-    expect(() =>
-      validateAuthConfig(null as unknown as AuthConfig)
-    ).toThrowError('Invalid auth config: JSON cannot be null or undefined.')
-  })
+  describe('For SASVIYA', () => {
+    it('should throw an error when authConfig is null', () => {
+      expect(() =>
+        validateAuthConfig(null as unknown as AuthConfig)
+      ).toThrowError('Invalid auth config: JSON cannot be null or undefined.')
+    })
 
-  it('should return the auth config when valid', () => {
-    expect(
-      validateAuthConfig({
+    it('should return the auth config when valid', () => {
+      expect(
+        validateAuthConfig({
+          access_token: 'T35T',
+          refresh_token: 'R3FR35H',
+          client: 'CL13NT',
+          secret: '53CR3T'
+        })
+      ).toEqual({
         access_token: 'T35T',
         refresh_token: 'R3FR35H',
         client: 'CL13NT',
         secret: '53CR3T'
       })
-    ).toEqual({
-      access_token: 'T35T',
-      refresh_token: 'R3FR35H',
-      client: 'CL13NT',
-      secret: '53CR3T'
+    })
+  })
+  describe('For SAS(', () => {
+    it('should throw an error when authConfigForSas9 is null', () => {
+      expect(() =>
+        validateAuthConfigForSas9(null as unknown as AuthConfigForSas9)
+      ).toThrowError(
+        'Invalid auth config for sas9: JSON cannot be null or undefined.'
+      )
+    })
+
+    it('should return the auth config for sas9 when valid', () => {
+      expect(
+        validateAuthConfigForSas9({
+          userName: 'TestUser',
+          password: 'TestPassword'
+        })
+      ).toEqual({
+        userName: 'TestUser',
+        password: 'TestPassword'
+      })
     })
   })
 })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -3,7 +3,7 @@ import { ServerType } from '.'
 import {
   DocConfig,
   AuthConfig,
-  AuthConfigForSas9,
+  AuthConfigSas9,
   BuildConfig,
   DeployConfig,
   JobConfig,
@@ -140,16 +140,21 @@ export const validateAuthConfig = (authConfig: AuthConfig): AuthConfig => {
   return authConfig
 }
 
-export const validateAuthConfigForSas9 = (
-  authConfigForSas9: AuthConfigForSas9
-): AuthConfigForSas9 => {
-  if (!authConfigForSas9) {
+export const validateAuthConfigSas9 = (
+  authConfigSas9: AuthConfigSas9
+): AuthConfigSas9 => {
+  if (!authConfigSas9) {
     throw new Error(
       'Invalid auth config for sas9: JSON cannot be null or undefined.'
     )
   }
+  if (!authConfigSas9.userName || !authConfigSas9.password) {
+    throw new Error(
+      'Invalid auth config for sas9: userName and password can not be empty'
+    )
+  }
 
-  return authConfigForSas9
+  return authConfigSas9
 }
 
 export const validateBuildConfig = (

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -3,6 +3,7 @@ import { ServerType } from '.'
 import {
   DocConfig,
   AuthConfig,
+  AuthConfigForSas9,
   BuildConfig,
   DeployConfig,
   JobConfig,
@@ -137,6 +138,18 @@ export const validateAuthConfig = (authConfig: AuthConfig): AuthConfig => {
   }
 
   return authConfig
+}
+
+export const validateAuthConfigForSas9 = (
+  authConfigForSas9: AuthConfigForSas9
+): AuthConfigForSas9 => {
+  if (!authConfigForSas9) {
+    throw new Error(
+      'Invalid auth config for sas9: JSON cannot be null or undefined.'
+    )
+  }
+
+  return authConfigForSas9
 }
 
 export const validateBuildConfig = (

--- a/src/utils/base64.spec.ts
+++ b/src/utils/base64.spec.ts
@@ -1,0 +1,13 @@
+import { encodeToBase64, decodeFromBase64 } from './base64'
+
+describe('base64', () => {
+  it('should return a base64 encoded string with encoded as prefix', () => {
+    expect(encodeToBase64('hello-world')).toEqual('ZW5jb2RlZGhlbGxvLXdvcmxk')
+  })
+
+  it('should return a decoded string with encoded as a prefix', () => {
+    expect(decodeFromBase64('ZW5jb2RlZGhlbGxvLXdvcmxk')).toEqual(
+      'encodedhello-world'
+    )
+  })
+})

--- a/src/utils/base64.spec.ts
+++ b/src/utils/base64.spec.ts
@@ -1,17 +1,13 @@
 import { encodeToBase64, decodeFromBase64 } from './base64'
 
 describe('base64', () => {
+  const originalPassword = 'hello-world'
   it('should return a base64 encoded string with prefix', () => {
-    const rawPassword = 'hello-world'
-    const encodedPassword =
-      'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
-    expect(encodeToBase64(rawPassword)).toEqual(encodedPassword)
+    expect(encodeToBase64(originalPassword)).toMatch(/^{sasjs_encoded}/)
   })
 
-  it('should return a decoded string without prefix', () => {
-    const encodedPassword =
-      'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
-    const originalPassword = 'hello-world'
+  it('should return original string without any prefix', () => {
+    const encodedPassword = encodeToBase64(originalPassword)
     expect(decodeFromBase64(encodedPassword)).toEqual(originalPassword)
   })
 

--- a/src/utils/base64.spec.ts
+++ b/src/utils/base64.spec.ts
@@ -2,12 +2,17 @@ import { encodeToBase64, decodeFromBase64 } from './base64'
 
 describe('base64', () => {
   it('should return a base64 encoded string with encoded as prefix', () => {
-    expect(encodeToBase64('hello-world')).toEqual('ZW5jb2RlZGhlbGxvLXdvcmxk')
+    const rawPassword = 'hello-world'
+    const encodedPassword =
+      'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
+    expect(encodeToBase64('hello-world')).toEqual(encodedPassword)
   })
 
   it('should return a decoded string with encoded as a prefix', () => {
-    expect(decodeFromBase64('ZW5jb2RlZGhlbGxvLXdvcmxk')).toEqual(
-      'encodedhello-world'
-    )
+    const encodedPassword =
+      'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
+    const passwordWithPrefix =
+      '2prwuP9bRG6dEJjJpn2zkqNN79GqCX1zUAKVc1JEat1YRXPsG7GF2T3R5Uo2EdiQm9uXv0zy0byYejxD0mRmB6sXfScwPJRA2BVCsaZwQxWFNSHeUMVkakSnAZhPx2Y730Bb4TH5SaCGWs2483G3UPtVLX2CoUZL4dbmA1UfSmUaX3suGGeZz18QFB66ke21PoNI0Cwahello-world'
+    expect(decodeFromBase64(encodedPassword)).toEqual(passwordWithPrefix)
   })
 })

--- a/src/utils/base64.spec.ts
+++ b/src/utils/base64.spec.ts
@@ -1,18 +1,23 @@
 import { encodeToBase64, decodeFromBase64 } from './base64'
 
 describe('base64', () => {
-  it('should return a base64 encoded string with encoded as prefix', () => {
+  it('should return a base64 encoded string with prefix', () => {
     const rawPassword = 'hello-world'
     const encodedPassword =
       'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
-    expect(encodeToBase64('hello-world')).toEqual(encodedPassword)
+    expect(encodeToBase64(rawPassword)).toEqual(encodedPassword)
   })
 
-  it('should return a decoded string with encoded as a prefix', () => {
+  it('should return a decoded string without prefix', () => {
     const encodedPassword =
       'MnByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
-    const passwordWithPrefix =
-      '2prwuP9bRG6dEJjJpn2zkqNN79GqCX1zUAKVc1JEat1YRXPsG7GF2T3R5Uo2EdiQm9uXv0zy0byYejxD0mRmB6sXfScwPJRA2BVCsaZwQxWFNSHeUMVkakSnAZhPx2Y730Bb4TH5SaCGWs2483G3UPtVLX2CoUZL4dbmA1UfSmUaX3suGGeZz18QFB66ke21PoNI0Cwahello-world'
-    expect(decodeFromBase64(encodedPassword)).toEqual(passwordWithPrefix)
+    const originalPassword = 'hello-world'
+    expect(decodeFromBase64(encodedPassword)).toEqual(originalPassword)
+  })
+
+  it('should return a raw password as it is because decoded string does not start with prefix', () => {
+    const rawPassword =
+      'SabirByd3VQOWJSRzZkRUpqSnBuMnprcU5ONzlHcUNYMXpVQUtWYzFKRWF0MVlSWFBzRzdHRjJUM1I1VW8yRWRpUW05dVh2MHp5MGJ5WWVqeEQwbVJtQjZzWGZTY3dQSlJBMkJWQ3NhWndReFdGTlNIZVVNVmtha1NuQVpoUHgyWTczMEJiNFRINVNhQ0dXczI0ODNHM1VQdFZMWDJDb1VaTDRkYm1BMVVmU21VYVgzc3VHR2VaejE4UUZCNjZrZTIxUG9OSTBDd2FoZWxsby13b3JsZA=='
+    expect(decodeFromBase64(rawPassword)).toEqual(rawPassword)
   })
 })

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -2,5 +2,10 @@ const PREFIX =
   '2prwuP9bRG6dEJjJpn2zkqNN79GqCX1zUAKVc1JEat1YRXPsG7GF2T3R5Uo2EdiQm9uXv0zy0byYejxD0mRmB6sXfScwPJRA2BVCsaZwQxWFNSHeUMVkakSnAZhPx2Y730Bb4TH5SaCGWs2483G3UPtVLX2CoUZL4dbmA1UfSmUaX3suGGeZz18QFB66ke21PoNI0Cwa'
 export const encodeToBase64 = (str: string) =>
   Buffer.from(PREFIX + str).toString('base64')
-export const decodeFromBase64 = (b64Encoded: string) =>
-  Buffer.from(b64Encoded, 'base64').toString()
+export const decodeFromBase64 = (str: string) => {
+  const decodedPassword = Buffer.from(str, 'base64').toString()
+  if (decodedPassword.startsWith(PREFIX)) {
+    return decodedPassword.split(PREFIX).pop()
+  }
+  return str
+}

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,4 +1,6 @@
+const PREFIX =
+  '2prwuP9bRG6dEJjJpn2zkqNN79GqCX1zUAKVc1JEat1YRXPsG7GF2T3R5Uo2EdiQm9uXv0zy0byYejxD0mRmB6sXfScwPJRA2BVCsaZwQxWFNSHeUMVkakSnAZhPx2Y730Bb4TH5SaCGWs2483G3UPtVLX2CoUZL4dbmA1UfSmUaX3suGGeZz18QFB66ke21PoNI0Cwa'
 export const encodeToBase64 = (str: string) =>
-  Buffer.from('encoded' + str).toString('base64')
+  Buffer.from(PREFIX + str).toString('base64')
 export const decodeFromBase64 = (b64Encoded: string) =>
   Buffer.from(b64Encoded, 'base64').toString()

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,11 +1,15 @@
-const PREFIX =
-  '2prwuP9bRG6dEJjJpn2zkqNN79GqCX1zUAKVc1JEat1YRXPsG7GF2T3R5Uo2EdiQm9uXv0zy0byYejxD0mRmB6sXfScwPJRA2BVCsaZwQxWFNSHeUMVkakSnAZhPx2Y730Bb4TH5SaCGWs2483G3UPtVLX2CoUZL4dbmA1UfSmUaX3suGGeZz18QFB66ke21PoNI0Cwa'
-export const encodeToBase64 = (str: string) =>
-  Buffer.from(PREFIX + str).toString('base64')
+import crypto from 'crypto'
+const PREFIX = '{sasjs_encoded}'
+export const encodeToBase64 = (str: string) => {
+  const randomString = crypto.randomBytes(100).toString('hex')
+  const encodedPassword = Buffer.from(randomString + str).toString('base64')
+  return PREFIX + encodedPassword
+}
 export const decodeFromBase64 = (str: string) => {
-  const decodedPassword = Buffer.from(str, 'base64').toString()
-  if (decodedPassword.startsWith(PREFIX)) {
-    return decodedPassword.split(PREFIX).pop()
+  if (str.startsWith(PREFIX)) {
+    str = str.replace(/^{sasjs_encoded}/, '')
+    const decodedPassword = Buffer.from(str, 'base64').toString()
+    return decodedPassword.substring(200)
   }
   return str
 }

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,0 +1,4 @@
+export const encodeToBase64 = (str: string) =>
+  Buffer.from('encoded' + str).toString('base64')
+export const decodeFromBase64 = (b64Encoded: string) =>
+  Buffer.from(b64Encoded, 'base64').toString()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
 export { asyncForEach, uuidv4 } from './utils'
 
 export { urlOrigin } from './url'
+
+export { encodeToBase64, decodeFromBase64 } from './base64'


### PR DESCRIPTION
## Intent

The intention is to add authconfig for sas9 server type add encoding decoding utility.

## Coverage Report
![Screenshot from 2021-07-02 14-41-48](https://user-images.githubusercontent.com/82647447/124255497-a9068280-db43-11eb-91eb-64d583b6860a.png)


## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/124257890-81102280-db35-11eb-92cd-9b7ab14f4ab4.png)
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/83717836/124257791-62119080-db35-11eb-9511-43f3aaa093be.png)
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
