### PR TITLE
fix: postinstall support windows CMD/Powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest --coverage",
     "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
     "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "postinstall": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
+    "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest --coverage",
     "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
     "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "postinstall": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
+    "postinstall": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Intent

NPM Postinstall command is not supported in windows CMD
Also move it to `prepare` instead of `postinstall`

## Implementation

Changed posinstall command from `[ -d .git ] && ...` to `git rev-parse --git-dir && ...`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
