### PR TITLE
fix(file-utils): use remove functions from fs-extra

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -109,11 +109,11 @@ export async function createFile(
 }
 
 export async function deleteFile(filePath: string) {
-  return fs.promises.unlink(filePath)
+  return fs.remove(filePath)
 }
 
 export async function deleteFolder(folderPath: string) {
-  return fs.promises.rmdir(folderPath, { recursive: true })
+  return fs.remove(folderPath)
 }
 
 export function unifyFilePath(


### PR DESCRIPTION
## Issue
Fixes https://github.com/sasjs/utils/issues/105.

## Intent

When running the `@sasjs/cli` tests locally, there are a number of random failures on cleanup steps, which are caused by folders not being empty. This is quite an annoyance as the tests take a long time to run, and random failures which have nothing to do with the current changes lead to a lot of time wastage.

## Implementation

Changed `deleteFile` and `deleteFolder` functions to use the `remove` function from `fs-extra`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
