### PR TITLE
chore(lint): fixed file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "postpublish": "git clean -fd",
     "package:lib": "npm run build && cp ./package.json build && cp README.md build && cd build && npm version \"5.0.0\" && npm pack",
     "test": "jest --coverage",
-    "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
+    "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
+    "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "repository": {


### PR DESCRIPTION
## Intent

Fix `lint` script for Windows environment.

## Implementation

Used `"` instead of `'` in file path used by `prettier`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/130939498-2caca9da-0e24-4df2-839f-523a45ac1a9a.png)
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/83717836/130939614-5d224c4a-6eaa-4c06-992b-41099bebc1a3.png)
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/130941770-7f0a4dcb-7645-474e-b70a-aeaa2763cf0c.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/130946764-4a694a7c-f16d-4bcf-8dfa-75ec440a8296.png)
- [x] Reviewer is assigned.
