### PR TITLE
fix: properties of Config are optional now

### DIFF
--- a/src/sasjsCli/getInitTerm.spec.ts
+++ b/src/sasjsCli/getInitTerm.spec.ts
@@ -16,9 +16,7 @@ const jobConfig = (root: boolean = true): JobConfig => ({
     : '/target/jobinitProgram/path',
   termProgram: root
     ? '/configuration/jobtermProgram/path'
-    : '/target/jobtermProgram/path',
-  jobFolders: [],
-  macroVars: {}
+    : '/target/jobtermProgram/path'
 })
 
 const serviceConfig = (root: boolean = true): ServiceConfig => ({
@@ -27,9 +25,7 @@ const serviceConfig = (root: boolean = true): ServiceConfig => ({
     : '/target/serviceinitProgram/path',
   termProgram: root
     ? '/configuration/servicetermProgram/path'
-    : '/target/servicetermProgram/path',
-  serviceFolders: [],
-  macroVars: {}
+    : '/target/servicetermProgram/path'
 })
 
 const testConfig = (root: boolean = true): TestConfig => ({
@@ -73,7 +69,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.job),
-        filePath: jobConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: jobConfig(false).initProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -85,7 +81,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.job),
-        filePath: jobConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: jobConfig(false).initProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Init Program of Configuration', async () => {
@@ -101,7 +97,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.job),
-        filePath: jobConfig().initProgram.replace(/\//g, path.sep)
+        filePath: jobConfig().initProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, jobConfig: undefined }
@@ -114,7 +110,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.job),
-        filePath: jobConfig().initProgram.replace(/\//g, path.sep)
+        filePath: jobConfig().initProgram!.replace(/\//g, path.sep)
       })
     })
   })
@@ -132,7 +128,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.service),
-        filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig(false).initProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -144,7 +140,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.service),
-        filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig(false).initProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Init Program of Configuration', async () => {
@@ -160,7 +156,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.service),
-        filePath: serviceConfig().initProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig().initProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, serviceConfig: undefined }
@@ -173,7 +169,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.service),
-        filePath: serviceConfig().initProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig().initProgram!.replace(/\//g, path.sep)
       })
     })
   })
@@ -191,7 +187,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.test),
-        filePath: testConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: testConfig(false).initProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -203,7 +199,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.test),
-        filePath: testConfig(false).initProgram.replace(/\//g, path.sep)
+        filePath: testConfig(false).initProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Init Program of Configuration', async () => {
@@ -219,7 +215,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.test),
-        filePath: testConfig().initProgram.replace(/\//g, path.sep)
+        filePath: testConfig().initProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, testConfig: undefined }
@@ -232,7 +228,7 @@ describe('getInit', () => {
         })
       ).resolves.toEqual({
         content: expectedInitContent(SASJsFileType.test),
-        filePath: testConfig().initProgram.replace(/\//g, path.sep)
+        filePath: testConfig().initProgram!.replace(/\//g, path.sep)
       })
     })
   })
@@ -252,7 +248,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.job),
-        filePath: jobConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: jobConfig(false).termProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -264,7 +260,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.job),
-        filePath: jobConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: jobConfig(false).termProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Term Program of Configuration', async () => {
@@ -280,7 +276,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.job),
-        filePath: jobConfig().termProgram.replace(/\//g, path.sep)
+        filePath: jobConfig().termProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, jobConfig: undefined }
@@ -293,7 +289,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.job),
-        filePath: jobConfig().termProgram.replace(/\//g, path.sep)
+        filePath: jobConfig().termProgram!.replace(/\//g, path.sep)
       })
     })
   })
@@ -311,7 +307,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.service),
-        filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig(false).termProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -323,7 +319,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.service),
-        filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig(false).termProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Term Program of Configuration', async () => {
@@ -339,7 +335,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.service),
-        filePath: serviceConfig().termProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig().termProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, serviceConfig: undefined }
@@ -352,7 +348,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.service),
-        filePath: serviceConfig().termProgram.replace(/\//g, path.sep)
+        filePath: serviceConfig().termProgram!.replace(/\//g, path.sep)
       })
     })
   })
@@ -370,7 +366,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.test),
-        filePath: testConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: testConfig(false).termProgram!.replace(/\//g, path.sep)
       })
 
       await expect(
@@ -382,7 +378,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.test),
-        filePath: testConfig(false).termProgram.replace(/\//g, path.sep)
+        filePath: testConfig(false).termProgram!.replace(/\//g, path.sep)
       })
     })
     test('should return with Term Program of Configuration', async () => {
@@ -398,7 +394,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.test),
-        filePath: testConfig().termProgram.replace(/\//g, path.sep)
+        filePath: testConfig().termProgram!.replace(/\//g, path.sep)
       })
 
       const newtarget = { ...target, testConfig: undefined }
@@ -411,7 +407,7 @@ describe('getTerm', () => {
         })
       ).resolves.toEqual({
         content: expectedTermContent(SASJsFileType.test),
-        filePath: testConfig().termProgram.replace(/\//g, path.sep)
+        filePath: testConfig().termProgram!.replace(/\//g, path.sep)
       })
     })
   })

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,9 +1,9 @@
 import { MacroVar } from './'
 
 export interface Config {
-  macroVars: MacroVar
-  initProgram: string
-  termProgram: string
+  macroVars?: MacroVar
+  initProgram?: string
+  termProgram?: string
 }
 export interface BuildConfig extends Config {
   buildOutputFileName: string
@@ -11,14 +11,14 @@ export interface BuildConfig extends Config {
   buildResultsFolder?: string
 }
 export interface ServiceConfig extends Config {
-  serviceFolders: string[]
+  serviceFolders?: string[]
 }
 export interface JobConfig extends Config {
-  jobFolders: string[]
+  jobFolders?: string[]
 }
 export interface TestConfig extends Config {
-  testSetUp: string
-  testTearDown: string
+  testSetUp?: string
+  testTearDown?: string
 }
 export interface DocConfig {
   displayMacroCore?: boolean

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -35,11 +35,13 @@ export interface TargetJson {
   name: string
   serverUrl: string
   serverType: ServerType
+  appLoc: string
+  macroFolders: string[]
+  programFolders: string[]
   httpsAgentOptions?: HttpsAgentOptions
   contextName?: string
   serverName?: string
   repositoryName?: string
-  appLoc: string
   docConfig?: DocConfig
   authConfig?: AuthConfig
   authConfigSas9?: AuthConfigSas9
@@ -48,8 +50,6 @@ export interface TargetJson {
   serviceConfig?: ServiceConfig
   jobConfig?: JobConfig
   streamConfig?: StreamConfig
-  macroFolders: string[]
-  programFolders: string[]
   isDefault?: boolean
   testConfig?: TestConfig
 }
@@ -70,15 +70,25 @@ export class Target implements TargetJson {
   }
   private _serverType = ServerType.SasViya
 
-  get httpsAgentOptions(): HttpsAgentOptions | undefined {
-    return this._httpsAgentOptions
-  }
-  private _httpsAgentOptions
-
   get appLoc(): string {
     return this._appLoc
   }
   private _appLoc
+
+  get macroFolders(): string[] {
+    return this._macroFolders
+  }
+  private _macroFolders: string[] = []
+
+  get programFolders(): string[] {
+    return this._programFolders
+  }
+  private _programFolders: string[] = []
+
+  get httpsAgentOptions(): HttpsAgentOptions | undefined {
+    return this._httpsAgentOptions
+  }
+  private _httpsAgentOptions
 
   get docConfig(): DocConfig | undefined {
     return this._docConfig
@@ -119,16 +129,6 @@ export class Target implements TargetJson {
     return this._streamConfig
   }
   private _streamConfig: StreamConfig | undefined
-
-  get macroFolders(): string[] {
-    return this._macroFolders
-  }
-  private _macroFolders: string[] = []
-
-  get programFolders(): string[] {
-    return this._programFolders
-  }
-  private _programFolders: string[] = []
 
   get contextName(): string {
     return this._contextName

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -260,7 +260,7 @@ describe('validateBuildConfig', () => {
     })
   })
 
-  it('should set the term program to the empty string if null', () => {
+  it('should unset the term program if null', () => {
     expect(
       validateBuildConfig(
         {
@@ -390,32 +390,27 @@ describe('validateServiceConfig', () => {
     ).toThrowError('Invalid service config: JSON cannot be null or undefined.')
   })
 
-  it('should set the init program to the empty string if null', () => {
+  it('should unset the init program  if null', () => {
     expect(
       validateServiceConfig({
         serviceFolders: [],
         initProgram: null
       } as unknown as ServiceConfig)
     ).toEqual({
-      serviceFolders: [],
-      initProgram: '',
-      termProgram: '',
-      macroVars: {}
+      serviceFolders: []
     })
   })
 
-  it('should set the term program to the empty string if null', () => {
+  it('should unset the term program if null', () => {
     expect(
       validateServiceConfig({
         serviceFolders: [],
         initProgram: 'test',
-        termProgram: ''
+        termProgram: null
       } as unknown as ServiceConfig)
     ).toEqual({
       serviceFolders: [],
-      initProgram: 'test',
-      termProgram: '',
-      macroVars: {}
+      initProgram: 'test'
     })
   })
 
@@ -435,17 +430,15 @@ describe('validateServiceConfig', () => {
     })
   })
 
-  it('should initialise the macro vars if not present', () => {
+  it('should unset the macro vars if not present', () => {
     expect(
       validateServiceConfig({
         initProgram: 'init',
         termProgram: 'term'
       } as unknown as ServiceConfig)
     ).toEqual({
-      serviceFolders: [],
       initProgram: 'init',
-      termProgram: 'term',
-      macroVars: {}
+      termProgram: 'term'
     })
   })
 })
@@ -463,32 +456,27 @@ describe('validateJobConfig', () => {
     ).toThrowError('Invalid job config: JSON cannot be null or undefined.')
   })
 
-  it('should set the init program to the empty string if null', () => {
+  it('should unset the init program if null', () => {
     expect(
       validateJobConfig({
         jobFolders: [],
         initProgram: null
       } as unknown as JobConfig)
     ).toEqual({
-      jobFolders: [],
-      initProgram: '',
-      termProgram: '',
-      macroVars: {}
+      jobFolders: []
     })
   })
 
-  it('should set the term program to the empty string if null', () => {
+  it('should unset the term program if null', () => {
     expect(
       validateJobConfig({
         jobFolders: [],
         initProgram: 'test',
-        termProgram: ''
+        termProgram: null
       } as unknown as JobConfig)
     ).toEqual({
       jobFolders: [],
-      initProgram: 'test',
-      termProgram: '',
-      macroVars: {}
+      initProgram: 'test'
     })
   })
 
@@ -508,17 +496,15 @@ describe('validateJobConfig', () => {
     })
   })
 
-  it('should initialise the macro vars if not present', () => {
+  it('should unset the macro vars if not present', () => {
     expect(
       validateJobConfig({
         initProgram: 'init',
         termProgram: 'term'
       } as unknown as JobConfig)
     ).toEqual({
-      jobFolders: [],
       initProgram: 'init',
-      termProgram: 'term',
-      macroVars: {}
+      termProgram: 'term'
     })
   })
 })
@@ -928,19 +914,13 @@ describe('validateTestConfig', () => {
   })
 
   let testInput = {}
-  let testOutput = {
-    initProgram: '',
-    termProgram: '',
-    macroVars: {},
-    testSetUp: '',
-    testTearDown: ''
-  }
+  let testOutput = {}
   const testAssertion = () =>
     expect(validateTestConfig(testInput as unknown as TestConfig)).toEqual(
       testOutput
     )
 
-  it('should set init program to the empty string if null', () => {
+  it('should unset init program if null', () => {
     testInput = {
       ...testInput,
       initProgram: null
@@ -949,30 +929,30 @@ describe('validateTestConfig', () => {
     testAssertion()
   })
 
-  it('should set term program to the empty string if null', () => {
+  it('should unset term program if null', () => {
     testInput = { ...testInput, initProgram: 'init', termProgram: null }
-    testOutput = { ...testOutput, initProgram: 'init', termProgram: '' }
+    testOutput = { ...testOutput, initProgram: 'init' }
 
     testAssertion()
   })
 
-  it('should initialise macro vars if not present', () => {
+  it('should unset macro vars if not present', () => {
     testInput = { ...testInput, termProgram: 'term', macroVars: null }
-    testOutput = { ...testOutput, termProgram: 'term', macroVars: {} }
+    testOutput = { ...testOutput, termProgram: 'term' }
 
     testAssertion()
   })
 
-  it('should set test set up to the empty string if null', () => {
+  it('should unset test set up if null', () => {
     testInput = { ...testInput, macroVars: {}, testSetUp: null }
-    testOutput = { ...testOutput, testSetUp: '' }
+    testOutput = { ...testOutput, macroVars: {} }
 
     testAssertion()
   })
 
-  it('should set test tear down to the empty string if null', () => {
+  it('should unset test tear down if null', () => {
     testInput = { ...testInput, testSetUp: 'testSetup', testTearDown: null }
-    testOutput = { ...testOutput, testSetUp: 'testSetup', testTearDown: '' }
+    testOutput = { ...testOutput, testSetUp: 'testSetup' }
 
     testAssertion()
   })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -193,57 +193,37 @@ export const validateBuildConfig = (
   if (!buildConfig) {
     throw new Error('Invalid build config: JSON cannot be null or undefined.')
   }
-  if (!buildConfig.buildResultsFolder) {
+
+  if (!buildConfig.buildResultsFolder)
     buildConfig.buildResultsFolder = 'sasjsresults'
-  }
 
-  if (!buildConfig.buildOutputFolder) {
+  if (!buildConfig.buildOutputFolder)
     buildConfig.buildOutputFolder = 'sasjsbuild'
-  }
 
-  if (!buildConfig.buildOutputFileName) {
+  if (!buildConfig.buildOutputFileName)
     buildConfig.buildOutputFileName = `${defaultName}.sas`
-  }
 
-  if (!buildConfig.initProgram) {
-    buildConfig.initProgram = ''
-  }
-
-  if (!buildConfig.termProgram) {
-    buildConfig.termProgram = ''
-  }
-
-  if (!buildConfig.macroVars) {
-    buildConfig.macroVars = {}
-  }
+  if (!buildConfig.initProgram) buildConfig.initProgram = ''
+  if (!buildConfig.termProgram) buildConfig.termProgram = ''
+  if (!buildConfig.macroVars) buildConfig.macroVars = {}
 
   return buildConfig
 }
 
 export const validateServiceConfig = (
-  serviceConfig: ServiceConfig
+  srvConf: ServiceConfig
 ): ServiceConfig => {
-  if (!serviceConfig) {
+  if (!srvConf) {
     throw new Error('Invalid service config: JSON cannot be null or undefined.')
   }
 
-  if (!serviceConfig.initProgram) {
-    serviceConfig.initProgram = ''
-  }
+  if (!validMacroVar(srvConf.macroVars)) srvConf.macroVars = undefined
+  if (!validStr(srvConf.initProgram)) srvConf.initProgram = undefined
+  if (!validStr(srvConf.termProgram)) srvConf.termProgram = undefined
 
-  if (!serviceConfig.termProgram) {
-    serviceConfig.termProgram = ''
-  }
+  if (!validStrArr(srvConf.serviceFolders)) srvConf.serviceFolders = undefined
 
-  if (!serviceConfig.serviceFolders) {
-    serviceConfig.serviceFolders = []
-  }
-
-  if (!serviceConfig.macroVars) {
-    serviceConfig.macroVars = {}
-  }
-
-  return serviceConfig
+  return srvConf
 }
 
 export const validateTestConfig = (testConfig: TestConfig): TestConfig => {
@@ -251,11 +231,12 @@ export const validateTestConfig = (testConfig: TestConfig): TestConfig => {
     throw new Error('Invalid test config: JSON cannot be null or undefined.')
   }
 
-  if (!testConfig.initProgram) testConfig.initProgram = ''
-  if (!testConfig.termProgram) testConfig.termProgram = ''
-  if (!testConfig.macroVars) testConfig.macroVars = {}
-  if (!testConfig.testSetUp) testConfig.testSetUp = ''
-  if (!testConfig.testTearDown) testConfig.testTearDown = ''
+  if (!validMacroVar(testConfig.macroVars)) testConfig.macroVars = undefined
+  if (!validStr(testConfig.initProgram)) testConfig.initProgram = undefined
+  if (!validStr(testConfig.termProgram)) testConfig.termProgram = undefined
+
+  if (!validStr(testConfig.testSetUp)) testConfig.testSetUp = undefined
+  if (!validStr(testConfig.testTearDown)) testConfig.testTearDown = undefined
 
   return testConfig
 }
@@ -265,21 +246,11 @@ export const validateJobConfig = (jobConfig: JobConfig): JobConfig => {
     throw new Error('Invalid job config: JSON cannot be null or undefined.')
   }
 
-  if (!jobConfig.initProgram) {
-    jobConfig.initProgram = ''
-  }
+  if (!validMacroVar(jobConfig.macroVars)) jobConfig.macroVars = undefined
+  if (!validStr(jobConfig.initProgram)) jobConfig.initProgram = undefined
+  if (!validStr(jobConfig.termProgram)) jobConfig.termProgram = undefined
 
-  if (!jobConfig.termProgram) {
-    jobConfig.termProgram = ''
-  }
-
-  if (!jobConfig.jobFolders) {
-    jobConfig.jobFolders = []
-  }
-
-  if (!jobConfig.macroVars) {
-    jobConfig.macroVars = {}
-  }
+  if (!validStrArr(jobConfig.jobFolders)) jobConfig.jobFolders = undefined
 
   return jobConfig
 }
@@ -293,9 +264,7 @@ export const validateDeployConfig = (
 
   deployConfig.deployServicePack = !!deployConfig.deployServicePack
 
-  if (!deployConfig.deployScripts) {
-    deployConfig.deployScripts = []
-  }
+  if (!deployConfig.deployScripts) deployConfig.deployScripts = []
 
   return deployConfig
 }
@@ -368,3 +337,13 @@ export const validateRepositoryName = (
 
   return repositoryName
 }
+
+const validStr = (input?: any): boolean => typeof input === 'string'
+
+const validStrArr = (input?: any[]): boolean =>
+  Array.isArray(input) && input.every((item) => validStr(item))
+
+const validMacroVar = (obj?: any): boolean =>
+  obj &&
+  !Array.isArray(obj) &&
+  Object.keys(obj).every((prop) => validStr(obj[prop]))


### PR DESCRIPTION
## Issue

[support partial config in cli](https://github.com/sasjs/cli/issues/1064)

## Intent

What this PR intends to achieve.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
