### PR TITLE
fix: writeFile with base64 string

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -103,7 +103,8 @@ export async function createFolder(
 
 export async function createFile(
   fileName: string,
-  content: string
+  content: string,
+  encoding?: BufferEncoding
 ): Promise<void> {
   fileName = unifyFilePath(fileName)
   if (fileName.split(path.sep).length > 1) {
@@ -116,7 +117,7 @@ export async function createFile(
     }
   }
 
-  return fs.promises.writeFile(fileName, content)
+  return fs.promises.writeFile(fileName, content, encoding)
 }
 
 export async function deleteFile(filePath: string) {


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

Write file with provided encoding

## Implementation

updated writeFile function with optional encoding.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
