### PR TITLE
fix(compile-tree): fixed CompileTree and add isWindows and newLine utils

### DIFF
--- a/src/compileTree/compileTree.ts
+++ b/src/compileTree/compileTree.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { createFile, readFile } from '../'
 import { getList, DependencyHeader, getDeprecatedHeader } from '../sasjsCli'
+import { newLine } from '../formatter'
 
 export interface Leaf {
   content: string
@@ -71,4 +72,7 @@ export class CompileTree {
 
 // Removes header from SAS file
 export const removeHeader = (content: string) =>
-  content.replace(new RegExp(`^\\/\\*[\\s\\S]*\\*\\/\\n\\n`), '')
+  content.replace(
+    new RegExp(`^\\/\\*[\\s\\S]*\\*\\/${newLine()}${newLine()}`),
+    ''
+  )

--- a/src/file/spec/file.spec.ts
+++ b/src/file/spec/file.spec.ts
@@ -25,6 +25,7 @@ import {
 import * as fileModule from '../file'
 import { generateTimestamp } from '../../time'
 import { svgBase64EncodedUnix, svgBase64EncodedWin } from './expectedOutputs'
+import { isWindows } from '../../utils'
 
 const content = 'test content'
 
@@ -393,7 +394,7 @@ describe('base64EncodeImageFile', () => {
     const filePath = path.join(__dirname, fileNameToEncode)
 
     await expect(base64EncodeImageFile(filePath)).resolves.toEqual(
-      process.platform === 'win32' ? svgBase64EncodedWin : svgBase64EncodedUnix
+      isWindows() ? svgBase64EncodedWin : svgBase64EncodedUnix
     )
   })
 })

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -1,3 +1,3 @@
 export { padWithNumber } from './number'
-
 export { sanitizeSpecialChars, capitalizeFirstChar } from './string'
+export { newLine } from './regexp'

--- a/src/formatter/regexp.spec.ts
+++ b/src/formatter/regexp.spec.ts
@@ -1,0 +1,20 @@
+import { newLine } from './'
+import { isWindows } from '../utils'
+
+describe('newLine', () => {
+  it('should return correct new line regexp entry for windows', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32'
+    })
+
+    expect(newLine()).toEqual('\\r\\n')
+  })
+
+  it('should return correct new line regexp entry for darwin', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin'
+    })
+
+    expect(newLine()).toEqual('\\n')
+  })
+})

--- a/src/formatter/regexp.ts
+++ b/src/formatter/regexp.ts
@@ -1,0 +1,3 @@
+import { isWindows } from '../'
+
+export const newLine = () => (isWindows() ? '\\r\\n' : '\\n')

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,4 +1,4 @@
-import { asyncForEach, uuidv4 } from './utils'
+import { asyncForEach, uuidv4, isWindows } from './utils'
 
 describe('uuidv4', () => {
   it('should generate 10000 uniq UUID', () => {
@@ -25,5 +25,11 @@ describe('asyncForEach', () => {
     await asyncForEach(chars, promise)
 
     expect(result).toEqual(expectedResult)
+  })
+})
+
+describe('isWindows', () => {
+  it('should return if current operation system is windows', () => {
+    expect(isWindows()).toEqual(process.platform === 'win32')
   })
 })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,3 +16,5 @@ export const uuidv4 = () =>
   })
 
 export const uniqArray = (data: any[]) => Array.from(new Set(data))
+
+export const isWindows = () => process.platform === 'win32'


### PR DESCRIPTION
## Intent

- Fix `removeHeader` for windows systems.

## Implementation

- Added `isWindows` util.
- Added `newLine` util.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [X] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
