### PR TITLE
fix(regexp): fixed newLine utility

### DIFF
--- a/src/formatter/regexp.spec.ts
+++ b/src/formatter/regexp.spec.ts
@@ -1,5 +1,4 @@
 import { newLine } from './'
-import { isWindows } from '../utils'
 
 describe('newLine', () => {
   it('should return correct new line regexp entry for windows', () => {

--- a/src/formatter/regexp.ts
+++ b/src/formatter/regexp.ts
@@ -1,3 +1,5 @@
-import { isWindows } from '../'
+// FIXME: if isWindows is used, it breaks cli.spec.ts because Logger is undefined
+// import { isWindows } from '../'
+// export const newLine = () => (isWindows() ? '\\r\\n' : '\\n')
 
-export const newLine = () => (isWindows() ? '\\r\\n' : '\\n')
+export const newLine = () => (process.platform === 'win32' ? '\\r\\n' : '\\n')


### PR DESCRIPTION
## Intent

Fix `cli.spec.ts` in `@sasjs/cli`.

## Implementation

- Used `process.platform` instead of `isWindows` utility in `newLine` utility

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
