### PR TITLE
Compile Tree improvements

### DIFF
--- a/src/compileTree/compileTree.ts
+++ b/src/compileTree/compileTree.ts
@@ -72,7 +72,4 @@ export class CompileTree {
 
 // Removes header from SAS file
 export const removeHeader = (content: string) =>
-  content.replace(
-    new RegExp(`^\\/\\*[\\s\\S]*\\*\\/${newLine()}${newLine()}`),
-    ''
-  )
+  content.replace(new RegExp(`\\/(\\*){1,2}([\\s\\S]*?)(\\*){1,2}\\/`), '')

--- a/src/sasjsCli/getInitTerm.spec.ts
+++ b/src/sasjsCli/getInitTerm.spec.ts
@@ -620,5 +620,7 @@ const getTestLeaf = (
 ): Leaf => ({
   content: isTerm ? initFileContent : termFileContent,
   dependencies: [],
-  location: getConfig(root)[`${isTerm ? 'init' : 'term'}Program`]
+  location: internalModule.unifyFilePath(
+    getConfig(root)[`${isTerm ? 'init' : 'term'}Program`]
+  )
 })

--- a/src/sasjsCli/getInitTerm.spec.ts
+++ b/src/sasjsCli/getInitTerm.spec.ts
@@ -9,37 +9,37 @@ import {
 } from '../types'
 import * as internalModule from '../file'
 import { getProgram, ProgramType } from './'
-import { CompileTree } from '../'
+import { CompileTree, Leaf } from '../'
 
 const jobConfig = (root: boolean = true): JobConfig => ({
   initProgram: root
-    ? '/configuration/jobinitProgram/init_path'
-    : '/target/jobinitProgram/init_path',
+    ? '/configuration/jobinitProgram/configuration_job_init_path'
+    : '/target/jobinitProgram/target_job_init_path',
   termProgram: root
-    ? '/configuration/jobtermProgram/term_path'
-    : '/target/jobtermProgram/term_path',
+    ? '/configuration/jobtermProgram/configuration_job_term_path'
+    : '/target/jobtermProgram/target_job_term_path',
   jobFolders: [],
   macroVars: {}
 })
 
 const serviceConfig = (root: boolean = true): ServiceConfig => ({
   initProgram: root
-    ? '/configuration/serviceinitProgram/path'
-    : '/target/serviceinitProgram/path',
+    ? '/configuration/serviceinitProgram/configuration_service_init_path'
+    : '/target/serviceinitProgram/target_service_init_path',
   termProgram: root
-    ? '/configuration/servicetermProgram/path'
-    : '/target/servicetermProgram/path',
+    ? '/configuration/servicetermProgram/configuration_service_term_path'
+    : '/target/servicetermProgram/target_service_term_path',
   serviceFolders: [],
   macroVars: {}
 })
 
 const testConfig = (root: boolean = true): TestConfig => ({
   initProgram: root
-    ? '/configuration/testinitProgram/path'
-    : '/target/testinitProgram/path',
+    ? '/configuration/testinitProgram/configuration_test_init_path'
+    : '/target/testinitProgram/target_test_init_path',
   termProgram: root
-    ? '/configuration/testtermProgram/path'
-    : '/target/testtermProgram/path',
+    ? '/configuration/testtermProgram/configuration_test_term_path'
+    : '/target/testtermProgram/target_test_term_path',
   macroVars: {},
   testSetUp: '',
   testTearDown: ''
@@ -60,17 +60,17 @@ const initFileContent = ' INIT FILE CONTENT '
 const termFileContent = ' TERM FILE CONTENT '
 
 describe('getInitTerm', () => {
+  let compileTree = new CompileTree('test_compileTree.json')
+
   describe('getInit', () => {
     describe('job', () => {
-      let compileTree = new CompileTree('test_compileTree.json', {
-        init_path: {
+      test('should return with Init Program of Target', async () => {
+        const initJobLeaf: Leaf = {
           content: initFileContent,
           dependencies: [],
-          location: 'init_path'
+          location: jobConfig(false).initProgram
         }
-      })
 
-      test('should return with Init Program of Target', async () => {
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -80,14 +80,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
             ProgramType.Init,
             compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.job),
-          filePath: jobConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: jobConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initJobLeaf
         })
 
         await expect(
@@ -96,17 +98,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.job),
-          filePath: jobConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: jobConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initJobLeaf
         })
       })
 
       test('should return with Init Program of Configuration', async () => {
+        const initJobLeaf = getTestLeaf(jobConfig)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -116,13 +123,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.job),
-          filePath: jobConfig().initProgram.replace(/\//g, path.sep)
+          filePath: jobConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initJobLeaf
         })
 
         compileTree = new CompileTree('test_compileTree.json', {})
@@ -135,20 +145,24 @@ describe('getInitTerm', () => {
               target: newTarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
             ProgramType.Init,
             compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.job),
-          filePath: jobConfig().initProgram.replace(/\//g, path.sep)
+          filePath: jobConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initJobLeaf
         })
       })
     })
 
     describe('service', () => {
       test('should return with Init Program of Target', async () => {
+        const initServiceLeaf = getTestLeaf(serviceConfig, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -158,13 +172,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.service),
-          filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initServiceLeaf
         })
 
         await expect(
@@ -173,17 +190,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.service),
-          filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initServiceLeaf
         })
       })
 
       test('should return with Init Program of Configuration', async () => {
+        const initServiceLeaf = getTestLeaf(serviceConfig)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -193,13 +215,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.service),
-          filePath: serviceConfig().initProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initServiceLeaf
         })
 
         const newtarget = { ...target, serviceConfig: undefined }
@@ -209,19 +234,24 @@ describe('getInitTerm', () => {
               target: newtarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.service),
-          filePath: serviceConfig().initProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initServiceLeaf
         })
       })
     })
 
     describe('test', () => {
       test('should return with Init Program of Target', async () => {
+        const initTestLeaf = getTestLeaf(testConfig, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -231,13 +261,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.test),
-          filePath: testConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: testConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initTestLeaf
         })
 
         await expect(
@@ -246,17 +279,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.test),
-          filePath: testConfig(false).initProgram.replace(/\//g, path.sep)
+          filePath: testConfig(false).initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initTestLeaf
         })
       })
 
       test('should return with Init Program of Configuration', async () => {
+        const initTestLeaf = getTestLeaf(testConfig)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(initFileContent))
@@ -266,13 +304,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.test),
-          filePath: testConfig().initProgram.replace(/\//g, path.sep)
+          filePath: testConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initTestLeaf
         })
 
         const newtarget = { ...target, testConfig: undefined }
@@ -282,13 +323,16 @@ describe('getInitTerm', () => {
               target: newtarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Init
+            ProgramType.Init,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedInitContent(SASJsFileType.test),
-          filePath: testConfig().initProgram.replace(/\//g, path.sep)
+          filePath: testConfig().initProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: initTestLeaf
         })
       })
     })
@@ -297,6 +341,8 @@ describe('getInitTerm', () => {
   describe('getTerm', () => {
     describe('job', () => {
       test('should return with Term Program of Target', async () => {
+        const termJobLeaf = getTestLeaf(jobConfig, false, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -306,13 +352,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.job),
-          filePath: jobConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: jobConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termJobLeaf
         })
 
         await expect(
@@ -321,17 +370,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.job),
-          filePath: jobConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: jobConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termJobLeaf
         })
       })
 
       test('should return with Term Program of Configuration', async () => {
+        const termJobLeaf = getTestLeaf(jobConfig, true, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -341,13 +395,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.job),
-          filePath: jobConfig().termProgram.replace(/\//g, path.sep)
+          filePath: jobConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termJobLeaf
         })
 
         const newtarget = { ...target, jobConfig: undefined }
@@ -357,19 +414,24 @@ describe('getInitTerm', () => {
               target: newtarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.job
+              fileType: SASJsFileType.job,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.job),
-          filePath: jobConfig().termProgram.replace(/\//g, path.sep)
+          filePath: jobConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termJobLeaf
         })
       })
     })
 
     describe('service', () => {
       test('should return with Term Program of Target', async () => {
+        const termServiceLeaf = getTestLeaf(serviceConfig, false, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -379,13 +441,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.service),
-          filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termServiceLeaf
         })
 
         await expect(
@@ -394,17 +459,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.service),
-          filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termServiceLeaf
         })
       })
 
       test('should return with Term Program of Configuration', async () => {
+        const termServiceLeaf = getTestLeaf(serviceConfig, true, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -414,13 +484,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.service),
-          filePath: serviceConfig().termProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termServiceLeaf
         })
 
         const newtarget = { ...target, serviceConfig: undefined }
@@ -430,19 +503,24 @@ describe('getInitTerm', () => {
               target: newtarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.service
+              fileType: SASJsFileType.service,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.service),
-          filePath: serviceConfig().termProgram.replace(/\//g, path.sep)
+          filePath: serviceConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termServiceLeaf
         })
       })
     })
 
     describe('test', () => {
       test('should return with Term Program of Target', async () => {
+        const termTestLeaf = getTestLeaf(testConfig, false, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -452,13 +530,16 @@ describe('getInitTerm', () => {
             {
               target: target as Target,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.test),
-          filePath: testConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: testConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termTestLeaf
         })
 
         await expect(
@@ -467,17 +548,22 @@ describe('getInitTerm', () => {
               target: target as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.test),
-          filePath: testConfig(false).termProgram.replace(/\//g, path.sep)
+          filePath: testConfig(false).termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termTestLeaf
         })
       })
 
       test('should return with Term Program of Configuration', async () => {
+        const termTestLeaf = getTestLeaf(testConfig, true, false)
+
         jest
           .spyOn(internalModule, 'readFile')
           .mockImplementation(() => Promise.resolve(termFileContent))
@@ -487,13 +573,16 @@ describe('getInitTerm', () => {
             {
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.test),
-          filePath: testConfig().termProgram.replace(/\//g, path.sep)
+          filePath: testConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termTestLeaf
         })
 
         const newtarget = { ...target, testConfig: undefined }
@@ -503,13 +592,16 @@ describe('getInitTerm', () => {
               target: newtarget as Target,
               configuration,
               buildSourceFolder,
-              fileType: SASJsFileType.test
+              fileType: SASJsFileType.test,
+              compileTree
             },
-            ProgramType.Term
+            ProgramType.Term,
+            compileTree
           )
         ).resolves.toEqual({
           content: expectedTermContent(SASJsFileType.test),
-          filePath: testConfig().termProgram.replace(/\//g, path.sep)
+          filePath: testConfig().termProgram.replace(/\//g, path.sep),
+          compileTreeLeaf: termTestLeaf
         })
       })
     })
@@ -520,3 +612,13 @@ const expectedInitContent = (type: SASJsFileType) =>
   `\n* ${type}Init start;\n${initFileContent}\n* ${type}Init end;`
 const expectedTermContent = (type: SASJsFileType) =>
   `\n* ${type}Term start;\n${termFileContent}\n* ${type}Term end;`
+
+const getTestLeaf = (
+  getConfig: (root: boolean) => JobConfig | TestConfig | ServiceConfig,
+  root = true,
+  isTerm = true
+): Leaf => ({
+  content: isTerm ? initFileContent : termFileContent,
+  dependencies: [],
+  location: getConfig(root)[`${isTerm ? 'init' : 'term'}Program`]
+})

--- a/src/sasjsCli/getInitTerm.spec.ts
+++ b/src/sasjsCli/getInitTerm.spec.ts
@@ -65,11 +65,7 @@ describe('getInitTerm', () => {
   describe('getInit', () => {
     describe('job', () => {
       test('should return with Init Program of Target', async () => {
-        const initJobLeaf: Leaf = {
-          content: initFileContent,
-          dependencies: [],
-          location: jobConfig(false).initProgram
-        }
+        const initJobLeaf = getTestLeaf(jobConfig, false)
 
         jest
           .spyOn(internalModule, 'readFile')

--- a/src/sasjsCli/loadDependenciesFile.ts
+++ b/src/sasjsCli/loadDependenciesFile.ts
@@ -36,13 +36,14 @@ export const loadDependenciesFile = async ({
   binaryFolders,
   compileTree
 }: LoadDependenciesParams) => {
-  const { init, initPath, term, termPath, startUpVars } = await getInitTerm({
-    configuration,
-    target,
-    fileType: type,
-    buildSourceFolder,
-    compileTree
-  })
+  const { init, initPath, term, termPath, startUpVars, initLeaf, termLeaf } =
+    await getInitTerm({
+      configuration,
+      target,
+      fileType: type,
+      buildSourceFolder,
+      compileTree
+    })
 
   fileContent = `\n* ${type} start;\n${fileContent}\n* ${type} end;`
 
@@ -57,14 +58,16 @@ export const loadDependenciesFile = async ({
     init,
     macroFolders,
     macroCorePath,
-    compileTree
+    compileTree,
+    initLeaf
   )
 
   const termDependencyPaths = await getDependencyPaths(
     term,
     macroFolders,
     macroCorePath,
-    compileTree
+    compileTree,
+    termLeaf
   )
 
   const allDependencyPaths = [


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/1164

## Intent

- Fix compilation issues detected in `@sasjs/core`

## Implementation

- Made `removeHeader` less greedy.
- Changed `getProgram` to also return `CompileTreeLeaf` that can be used to get the dependencies.
- Adjusted unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
<img width="358" alt="image" src="https://user-images.githubusercontent.com/25773492/158811421-09f1c71d-3ae6-4795-ac25-43aa1dacdd27.png">
- [] All `sasjs-cli` unit tests are passing (`npm test`).
Mocked:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/25773492/158811493-dc272f6f-cce2-431c-9602-d870229e5172.png">
- [] Reviewer is assigned.
