### PR TITLE
fix(types): define explicit types

### DIFF
--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -16,11 +16,12 @@ export interface FileMember {
   code: string
 }
 
-export interface FileTree {
+export interface FolderMember {
+  name: string
+  type: MemberType.folder
   members: (FolderMember | ServiceMember | FileMember)[]
 }
 
-export interface FolderMember extends FileTree {
-  name: string
-  type: MemberType.folder
+export interface FileTree {
+  members: (FolderMember | ServiceMember | FileMember)[]
 }


### PR DESCRIPTION
## Issue

No issue to link

## Intent

[tsoa](https://www.npmjs.com/package/tsoa) swagger docs generation cannot parse Type define with `extends`.

## Implementation

Reverted code to explicit types:
From 
```
export interface FileTree {
  members: (FolderMember | ServiceMember | FileMember)[]
}

export interface FolderMember extends FileTree {
  name: string
  type: MemberType.folder
}
```
To
```
export interface FolderMember {
  name: string
  type: MemberType.folder
  members: (FolderMember | ServiceMember | FileMember)[]
}

export interface FileTree {
  members: (FolderMember | ServiceMember | FileMember)[]
}
```

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
