### PR TITLE
feat: add utility getOSSpecificPath

### DIFF
--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -3,7 +3,7 @@ import {
   uuidv4,
   isWindows,
   isLinux,
-  getOSSpecificPath
+  escapeWinSlashes
 } from './utils'
 import * as utilsModule from './utils'
 
@@ -47,12 +47,12 @@ describe('isLinux', () => {
   })
 })
 
-describe('getOSSpecificPath', () => {
+describe('escapeWinSlashes', () => {
   describe('when platform is win32', () => {
     it('should return the path with double backslashes', () => {
       jest.spyOn(utilsModule, 'isWindows').mockImplementationOnce(() => true)
       const path = 'some\\file\\path'
-      expect(getOSSpecificPath(path)).toEqual('some\\\\file\\\\path')
+      expect(escapeWinSlashes(path)).toEqual('some\\\\file\\\\path')
     })
   })
 
@@ -60,7 +60,7 @@ describe('getOSSpecificPath', () => {
     it('should return the path as it is ', () => {
       jest.spyOn(utilsModule, 'isWindows').mockImplementationOnce(() => false)
       const path = 'some/file/path'
-      expect(getOSSpecificPath(path)).toEqual(path)
+      expect(escapeWinSlashes(path)).toEqual(path)
     })
   })
 })

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,8 +1,15 @@
-import { asyncForEach, uuidv4, isWindows, isLinux } from './utils'
+import {
+  asyncForEach,
+  uuidv4,
+  isWindows,
+  isLinux,
+  getOSSpecificPath
+} from './utils'
+import * as utilsModule from './utils'
 
 describe('uuidv4', () => {
   it('should generate 10000 uniq UUID', () => {
-    const uuids = []
+    const uuids: string[] = []
 
     for (let i = 0; i < 10 * 1000; i++) {
       const uuid = uuidv4()
@@ -37,5 +44,23 @@ describe('isWindows', () => {
 describe('isLinux', () => {
   it('should return if current operation system is linux', () => {
     expect(isLinux()).toEqual(process.platform === 'linux')
+  })
+})
+
+describe('getOSSpecificPath', () => {
+  describe('when platform is win32', () => {
+    it('should return the path with double backslashes', () => {
+      jest.spyOn(utilsModule, 'isWindows').mockImplementationOnce(() => true)
+      const path = 'some\\file\\path'
+      expect(getOSSpecificPath(path)).toEqual('some\\\\file\\\\path')
+    })
+  })
+
+  describe('when platform is not win32', () => {
+    it('should return the path as it is ', () => {
+      jest.spyOn(utilsModule, 'isWindows').mockImplementationOnce(() => false)
+      const path = 'some/file/path'
+      expect(getOSSpecificPath(path)).toEqual(path)
+    })
   })
 })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -21,5 +21,8 @@ export const isWindows = () => process.platform === 'win32'
 
 export const isLinux = () => process.platform === 'linux'
 
-export const getOSSpecificPath = (path: string) =>
+/**
+ * replace single backslash with double backslash
+ */
+export const escapeWinSlashes = (path: string) =>
   isWindows() ? path.replace(/\\/g, '\\\\') : path

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,3 +20,6 @@ export const uniqArray = (data: any[]) => Array.from(new Set(data))
 export const isWindows = () => process.platform === 'win32'
 
 export const isLinux = () => process.platform === 'linux'
+
+export const getOSSpecificPath = (path: string) =>
+  isWindows() ? path.replace(/\\/g, '\\\\') : path


### PR DESCRIPTION
## Intent

* replace single backslash with a double backslash if `process.platform` is `win32`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
