### PR TITLE
fix: always use / as path separator in the generated SAS code

### DIFF
--- a/src/fs/generateCompileProgram.ts
+++ b/src/fs/generateCompileProgram.ts
@@ -44,7 +44,9 @@ const fileAndDirectoryCreationCode = async (
     const folderPath = path.join(resourcePath, folder)
 
     resultCode = `${resultCode}
-%mf_mkdir(&fsTarget${generatePathForSas(folderPath.replace(pathRelativeTo, ''))})
+%mf_mkdir(&fsTarget${generatePathForSas(
+      folderPath.replace(pathRelativeTo, '')
+    )})
 `
 
     resultCode = await fileAndDirectoryCreationCode(

--- a/src/fs/generateCompileProgram.ts
+++ b/src/fs/generateCompileProgram.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { isFolder, listFilesInFolder, listSubFoldersInFolder } from '../file'
+import { generatePathForSas } from '../utils'
 import {
   getInitialCode,
   getCompiledMacrosCode,
@@ -43,7 +44,7 @@ const fileAndDirectoryCreationCode = async (
     const folderPath = path.join(resourcePath, folder)
 
     resultCode = `${resultCode}
-%mf_mkdir(&fsTarget${folderPath.replace(pathRelativeTo, '')})
+%mf_mkdir(&fsTarget${generatePathForSas(folderPath.replace(pathRelativeTo, ''))})
 `
 
     resultCode = await fileAndDirectoryCreationCode(

--- a/src/fs/internal/helper.ts
+++ b/src/fs/internal/helper.ts
@@ -15,7 +15,9 @@ file _in64;
 ${chunkedFileContent}
 run;
 
-filename _out64 "&fsTarget${generatePathForSas(filePath.replace(pathRelativeTo, ''))}";
+filename _out64 "&fsTarget${generatePathForSas(
+    filePath.replace(pathRelativeTo, '')
+  )}";
 
 /* convert from base64 */
 data _null_;

--- a/src/fs/internal/helper.ts
+++ b/src/fs/internal/helper.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { chunk, getMacrosPath } from '../../utils'
+import { chunk, getMacrosPath, generatePathForSas } from '../../utils'
 import { readFile, base64EncodeFile } from '../../file'
 
 export const generateCodeForFileCreation = async (
@@ -15,7 +15,7 @@ file _in64;
 ${chunkedFileContent}
 run;
 
-filename _out64 "&fsTarget${filePath.replace(pathRelativeTo, '')}";
+filename _out64 "&fsTarget${generatePathForSas(filePath.replace(pathRelativeTo, ''))}";
 
 /* convert from base64 */
 data _null_;

--- a/src/fs/spec/createFSCompileProgram.spec.ts
+++ b/src/fs/spec/createFSCompileProgram.spec.ts
@@ -29,7 +29,7 @@ describe('createFSCompileProgram', () => {
 
     expect(program).toContain('%macro mf_mkdir')
     expect(program).toContain('%mf_mkdir(&fsTarget)')
-    expect(program).toContain(`%mf_mkdir(&fsTarget${path.sep}subFolder)`)
+    expect(program).toContain(`%mf_mkdir(&fsTarget/subFolder)`)
   })
 })
 

--- a/src/fs/sync.ts
+++ b/src/fs/sync.ts
@@ -5,6 +5,7 @@ import {
   generateCodeForFileCreation
 } from './internal/helper'
 import { HashedFolder } from '../types'
+import { generatePathForSas } from '../utils'
 
 export const generateProgramToGetRemoteHash = async (remotePath: string) => {
   const compiledMacrosCode = await getCompiledMacrosCode([
@@ -72,10 +73,10 @@ const generateCodeForFolderCreation = async (
         pathRelativeTo
       )
     } else {
-      resultCode += `%mf_mkdir(&fsTarget${member.absolutePath.replace(
+      resultCode += `%mf_mkdir(&fsTarget${generatePathForSas(member.absolutePath.replace(
         pathRelativeTo,
         ''
-      )})\n`
+      ))})\n`
       resultCode = await generateCodeForFolderCreation(
         member as HashedFolder,
         pathRelativeTo,
@@ -109,8 +110,8 @@ run;
 `
 }
 
-const setTargetAtStart = (code: string, target: string) => {
-  return `%let fsTarget=${target};\n${code}`
+const setTargetAtStart = (code: string, targetPath: string) => {
+  return `%let fsTarget=${generatePathForSas(targetPath)};\n${code}`
 }
 
 /**

--- a/src/fs/sync.ts
+++ b/src/fs/sync.ts
@@ -73,10 +73,9 @@ const generateCodeForFolderCreation = async (
         pathRelativeTo
       )
     } else {
-      resultCode += `%mf_mkdir(&fsTarget${generatePathForSas(member.absolutePath.replace(
-        pathRelativeTo,
-        ''
-      ))})\n`
+      resultCode += `%mf_mkdir(&fsTarget${generatePathForSas(
+        member.absolutePath.replace(pathRelativeTo, '')
+      )})\n`
       resultCode = await generateCodeForFolderCreation(
         member as HashedFolder,
         pathRelativeTo,

--- a/src/types/sasjsconfig-schema.json
+++ b/src/types/sasjsconfig-schema.json
@@ -689,6 +689,24 @@
       "description": "The contents of this folder are simply copied to the sasjsbuild directory AFTER the rest of the project is compiled.  Useful for synchronising random / generic content with SAS logical folders.",
       "default": "sasjs/static_files"
     },
+    "syncDirectories": {
+      "$id": "#/properties/syncDirectories",
+      "type": "array",
+      "title": "syncDirectories",
+      "description": "Maps the local filesystem to remote (SAS) physical directories.",
+      "examples": [
+        [
+          {
+            "local": "C:\\temp\\local\\fs1",
+            "remote": "/opt/data/fs1"
+          },
+          {
+            "local": "C:\\temp\\elsewhere",
+            "remote": "/opt/somewhere"
+          }
+        ]
+      ]
+    },
     "targets": {
       "$id": "#/properties/targets",
       "type": "array",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,8 @@ export {
   isWindows,
   isLinux,
   escapeWinSlashes,
-  getMacrosPath
+  getMacrosPath,
+  generatePathForSas
 } from './utils'
 export * from './fileTree'
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -35,4 +35,5 @@ export const getMacrosPath = () => path.join(__dirname, '..', 'macros')
  * sas code requires forward slashes as path separator in file or folder paths.
  * So, this method replaces OS specific path separator with forward slash
  */
-export const generatePathForSas = (resourcePath: string) => resourcePath.replace(path.sep, '/')
+export const generatePathForSas = (resourcePath: string) =>
+  resourcePath.replace(path.sep, '/')

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -30,3 +30,9 @@ export const escapeWinSlashes = (path: string) =>
   isWindows() ? path.replace(/\\/g, '\\\\') : path
 
 export const getMacrosPath = () => path.join(__dirname, '..', 'macros')
+
+/**
+ * sas code requires forward slashes as path separator in file or folder paths.
+ * So, this method replaces OS specific path separator with forward slash
+ */
+export const generatePathForSas = (resourcePath: string) => resourcePath.replace(path.sep, '/')


### PR DESCRIPTION
## Issue

closes #214

## Intent

* sas code requires forward slashes as the path separators in file or folder paths. So replaced os specific path separators with a forward slash `/`.

## Implementation

* created a utility that replaces path separator in a string with `/`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
