### PR TITLE
fix: add more macro dependencies to generated programs

### DIFF
--- a/src/fs/generateCompileProgram.ts
+++ b/src/fs/generateCompileProgram.ts
@@ -8,7 +8,14 @@ import {
 } from './internal/helper'
 
 export const generateCompileProgram = async (folderPath: string) => {
-  const compiledMacrosCode = await getCompiledMacrosCode(['mf_mkdir.sas'])
+  const compiledMacrosCode = await getCompiledMacrosCode([
+    'mf_mkdir.sas',
+    'mp_dirlist.sas',
+    'mf_existds.sas',
+    'mf_getvarlist.sas',
+    'mf_wordsinstr1butnotstr2.sas',
+    'mp_dropmembers.sas'
+  ])
 
   const initialProgramContent = getInitialCode()
 

--- a/src/fs/sync.ts
+++ b/src/fs/sync.ts
@@ -10,7 +10,13 @@ import { generatePathForSas } from '../utils'
 export const generateProgramToGetRemoteHash = async (remotePath: string) => {
   const compiledMacrosCode = await getCompiledMacrosCode([
     'mp_hashdirectory.sas',
-    'mp_jsonout.sas'
+    'mp_jsonout.sas',
+    'mp_dirlist.sas',
+    'mf_existds.sas',
+    'mf_getvarlist.sas',
+    'mf_wordsinstr1butnotstr2.sas',
+    'mp_dropmembers.sas',
+    'mf_isblank.sas'
   ])
 
   const codeForHashCreation = getCodeForHashCreation()
@@ -27,7 +33,13 @@ export const generateProgramToSyncHashDiff = async (
   const compiledMacrosCode = await getCompiledMacrosCode([
     'mp_hashdirectory.sas',
     'mp_jsonout.sas',
-    'mf_mkdir.sas'
+    'mf_mkdir.sas',
+    'mp_dirlist.sas',
+    'mf_existds.sas',
+    'mf_getvarlist.sas',
+    'mf_wordsinstr1butnotstr2.sas',
+    'mp_dropmembers.sas',
+    'mf_isblank.sas'
   ])
 
   const initialProgramContent = getInitialCode()
@@ -44,6 +56,7 @@ export const generateProgramToSyncHashDiff = async (
   const codeForHashCreation = getCodeForHashCreation()
 
   const code =
+    'options ls=max;' +
     compiledMacrosCode +
     initialProgramContent +
     folderCreationCode +


### PR DESCRIPTION

## Intent

* sasjs fs sync and sasjs fs compile needs some more macros as dependencies in generated program


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
