### PR TITLE
fix: move extractHashArray function to utils

### DIFF
--- a/src/fs/hash.ts
+++ b/src/fs/hash.ts
@@ -36,6 +36,24 @@ export function compareHashes(
   return hashDifference(localHash, remoteHashMap)
 }
 
+export const extractHashArray = (log: string) => {
+  if (log.includes('>>weboutBEGIN<<')) {
+    try {
+      const webout = log
+        .split(/>>weboutBEGIN<<\n/)[1]
+        .split(/>>weboutEND<<\n/)[0]
+
+      const weboutWithoutLF = webout.replace(/\n|\r\n/g, '')
+      const jsonWebout = JSON.parse(weboutWithoutLF)
+      return jsonWebout.hashes
+    } catch (err: any) {
+      throw new Error(
+        `An error occurred while extracting hashes array from webout: ${err.message}`
+      )
+    }
+  }
+}
+
 const hashDifference = (
   localHash: HashedFolder,
   remoteHashMap: { [key: string]: string },

--- a/src/fs/hash.ts
+++ b/src/fs/hash.ts
@@ -40,8 +40,8 @@ export const extractHashArray = (log: string) => {
   if (log.includes('>>weboutBEGIN<<')) {
     try {
       const webout = log
-        .split(/>>weboutBEGIN<<\n/)[1]
-        .split(/>>weboutEND<<\n/)[0]
+        .split(/>>weboutBEGIN<<(\n|\r\n)/)[1]
+        .split(/>>weboutEND<<(\n|\r\n)/)[0]
 
       const weboutWithoutLF = webout.replace(/\n|\r\n/g, '')
       const jsonWebout = JSON.parse(weboutWithoutLF)

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -1,4 +1,4 @@
-export { getHash, compareHashes } from './hash'
+export { getHash, compareHashes, extractHashArray } from './hash'
 export { generateCompileProgram } from './generateCompileProgram'
 export {
   generateProgramToGetRemoteHash,

--- a/src/fs/spec/hash.spec.ts
+++ b/src/fs/spec/hash.spec.ts
@@ -52,8 +52,6 @@ describe('extractHashArray', () => {
 
   it('should throw an error when webout is not valid json', () => {
     const logContent = `>>weboutBEGIN<<\n${webout}\n>>weboutEND<<\n`
-    expect(() => extractHashArray(logContent)).toThrowError(
-      `An error occurred while extracting hashes array from webout: "[object Object]" is not valid JSON`
-    )
+    expect(() => extractHashArray(logContent)).toThrowError()
   })
 })

--- a/src/fs/spec/hash.spec.ts
+++ b/src/fs/spec/hash.spec.ts
@@ -1,5 +1,28 @@
 import path from 'path'
-import { getHash, compareHashes } from '../hash'
+import { getHash, compareHashes, extractHashArray } from '../hash'
+
+const webout = {
+  hashes: [
+    {
+      DIRECTORY: '/export/pvs/sasdata/homes/viyademo08f/stephan/extract',
+      FILE_HASH: 'F041B4AF15A7F844D20F45BA4F5EE1B4',
+      HASH_DURATION: 0.0069699287,
+      FILE_PATH:
+        '/export/pvs/sasdata/homes/viyademo08f/stephan/extract/makedata2.sas',
+      FILE_OR_FOLDER: 'file',
+      LEVEL: 1
+    },
+    {
+      DIRECTORY: '/export/pvs/sasdata/homes/viyademo08f/stephan/load',
+      FILE_HASH: '616C9FA7A70C53AF4D335BE546B62441',
+      HASH_DURATION: 0.007089138,
+      FILE_PATH:
+        '/export/pvs/sasdata/homes/viyademo08f/stephan/load/runjob1.test.sas',
+      FILE_OR_FOLDER: 'file',
+      LEVEL: 1
+    }
+  ]
+}
 
 describe('getHash', () => {
   it('should return the hash of provided directory', async () => {
@@ -15,5 +38,22 @@ describe('compareHashes', () => {
     const hashedFolder = await getHash(path.join(__dirname, 'hashFolder'))
     const hashedDiff = compareHashes(hashedFolder, {})
     expect(hashedDiff).toEqual(hashedFolder)
+  })
+})
+
+describe('extractHashArray', () => {
+  it('should extract and return a hash array', () => {
+    const logContent = `>>weboutBEGIN<<\n${JSON.stringify(
+      webout
+    )}\n>>weboutEND<<\n`
+    const hashes = extractHashArray(logContent)
+    expect(hashes).toEqual(webout.hashes)
+  })
+
+  it('should throw an error when webout is not valid json', () => {
+    const logContent = `>>weboutBEGIN<<\n${webout}\n>>weboutEND<<\n`
+    expect(() => extractHashArray(logContent)).toThrowError(
+      `An error occurred while extracting hashes array from webout: "[object Object]" is not valid JSON`
+    )
   })
 })


### PR DESCRIPTION
## Intent

Move extract hash array function from cli and extension to utils

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
