### PR TITLE
feat: add a new method listSasFilesInFolder

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -47,7 +47,14 @@ export async function listIniFilesInFolder(folderName: string) {
     name.endsWith('.ini')
   )
 }
-
+/**
+ * This function returns a list of all SAS files in a folder
+ *
+ * @param folderName a string that contains the folder path
+ * @param recurse (optional) a boolean that identifies the searching of sas files in nested folders recursively
+ * @param ignoredFolders (optional) a string array that contains the folders to be ignored in recursive search
+ * @returns a string array containing sas files paths relatived to folderName
+ */
 export async function listSasFilesInFolder(
   folderName: string,
   recurse: boolean = false,

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -93,9 +93,13 @@ export async function listFilesAndSubFoldersInFolder(
 
                 subFoldersFilesAndFolders = [
                   ...subFoldersFilesAndFolders,
-                  ...(await listFilesAndSubFoldersInFolder(subPath)).map((f) =>
-                    path.join(subFolder, f)
-                  )
+                  ...(
+                    await listFilesAndSubFoldersInFolder(
+                      subPath,
+                      recurse,
+                      ignoredFolders
+                    )
+                  ).map((f) => path.join(subFolder, f))
                 ]
               }
             }

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -48,6 +48,20 @@ export async function listIniFilesInFolder(folderName: string) {
   )
 }
 
+export async function listSasFilesInFolder(
+  folderName: string,
+  recurse: boolean = false,
+  ignoredFolders: string[] = []
+) {
+  const filesAndFolders = await listFilesAndSubFoldersInFolder(
+    folderName,
+    recurse,
+    ignoredFolders
+  )
+  const sasFiles = filesAndFolders.filter((f) => f.endsWith('.sas'))
+  return sasFiles
+}
+
 export async function listSubFoldersInFolder(
   folderName: string
 ): Promise<string[]> {
@@ -58,7 +72,8 @@ export async function listSubFoldersInFolder(
 
 export async function listFilesAndSubFoldersInFolder(
   folderName: string,
-  recurse: boolean = true
+  recurse: boolean = true,
+  ignoredFolders: string[] = []
 ): Promise<string[]> {
   return fs.promises
     .readdir(folderName, { withFileTypes: true })
@@ -73,14 +88,16 @@ export async function listFilesAndSubFoldersInFolder(
             list.filter((f) => f.isDirectory()),
             async (f) => {
               const subFolder = f.name
-              const subPath = path.join(folderName, subFolder)
+              if (!ignoredFolders.includes(subFolder)) {
+                const subPath = path.join(folderName, subFolder)
 
-              subFoldersFilesAndFolders = [
-                ...subFoldersFilesAndFolders,
-                ...(await listFilesAndSubFoldersInFolder(subPath)).map((f) =>
-                  path.join(subFolder, f)
-                )
-              ]
+                subFoldersFilesAndFolders = [
+                  ...subFoldersFilesAndFolders,
+                  ...(await listFilesAndSubFoldersInFolder(subPath)).map((f) =>
+                    path.join(subFolder, f)
+                  )
+                ]
+              }
             }
           )
 

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -6,6 +6,7 @@ export {
   readFileBinary,
   listFilesInFolder,
   listIniFilesInFolder,
+  listSasFilesInFolder,
   listSubFoldersInFolder,
   listFilesAndSubFoldersInFolder,
   createFile,


### PR DESCRIPTION
## Intent

* Add a new helper method in the file module which will list all SAS files in a folder.
* This method has the ability to fetch files from nested folders
* also has the ability to ignore some specified folders while extracting files in a nested approach


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
