### PR TITLE
fix: update error message when webSourcePath is missing and streamConfig is true

### DIFF
--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -630,7 +630,7 @@ describe('validateStreamConfig', () => {
         webSourcePath: ''
       } as unknown as StreamConfig)
     ).toThrowError(
-      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+      'Invalid stream config: `webSourcePath` should contain the path to your frontend application eg build, dist, or src.'
     )
   })
 
@@ -642,7 +642,7 @@ describe('validateStreamConfig', () => {
         webSourcePath: null
       } as unknown as StreamConfig)
     ).toThrowError(
-      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+      'Invalid stream config: `webSourcePath` should contain the path to your frontend application eg build, dist, or src.'
     )
   })
 
@@ -654,7 +654,7 @@ describe('validateStreamConfig', () => {
         webSourcePath: undefined
       } as unknown as StreamConfig)
     ).toThrowError(
-      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+      'Invalid stream config: `webSourcePath` should contain the path to your frontend application eg build, dist, or src.'
     )
   })
 

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -322,7 +322,7 @@ export const validateStreamConfig = (
 
   if (streamConfig.streamWeb && !streamConfig.webSourcePath) {
     throw new Error(
-      'Invalid stream config: `webSourcePath` cannot be empty, null or undefined.'
+      'Invalid stream config: `webSourcePath` should contain the path to your frontend application eg build, dist, or src.'
     )
   }
 


### PR DESCRIPTION
## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
