### PR TITLE
feat: add sasjsBuildFolder and sasjsResultsFolder to configuration

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -19,8 +19,6 @@ export interface Config {
 
 export interface BuildConfig extends Config {
   buildOutputFileName: string
-  buildOutputFolder?: string
-  buildResultsFolder?: string
 }
 
 export interface ServiceConfig extends Config {

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -14,6 +14,8 @@ import { HttpsAgentOptions } from './httpsAgentOptions'
 
 export interface Configuration {
   $schema?: string
+  sasjsBuildFolder?: string
+  sasjsResultsFolder?: string
   httpsAgentOptions?: HttpsAgentOptions
   docConfig?: DocConfig
   buildConfig?: BuildConfig

--- a/src/types/target.spec.ts
+++ b/src/types/target.spec.ts
@@ -80,6 +80,116 @@ describe('Target', () => {
     expect(target.syncFolder).toBeUndefined()
   })
 
+  it('should create an instance when the JSON is valid and contains sasjsBuildFolder', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      sasjsBuildFolder: 'sasjsbuild'
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.sasjsBuildFolder).toEqual('sasjsbuild')
+  })
+
+  it('should convert an instance to JSON when containing sasjsBuildFolder', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      sasjsBuildFolder: 'sasjsbuild'
+    })
+
+    const json = target.toJson()
+    expect(json).toBeTruthy()
+    expect(json.name).toEqual('test')
+    expect(json.serverUrl).toEqual('')
+    expect(json.serverType).toEqual(ServerType.Sas9)
+    expect(json.appLoc).toEqual('/test')
+    expect(json.sasjsBuildFolder).toEqual('sasjsbuild')
+  })
+
+  it('should create an instance when the JSON is valid and contains sasjsResultsFolder', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      sasjsResultsFolder: 'sasjsresults'
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.sasjsResultsFolder).toEqual('sasjsresults')
+  })
+
+  it('should convert an instance to JSON containing sasjsResultsFolder', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      sasjsResultsFolder: 'sasjsresults'
+    })
+
+    const json = target.toJson()
+    expect(json).toBeTruthy()
+    expect(json.name).toEqual('test')
+    expect(json.serverUrl).toEqual('')
+    expect(json.serverType).toEqual(ServerType.Sas9)
+    expect(json.appLoc).toEqual('/test')
+    expect(json.sasjsResultsFolder).toEqual('sasjsresults')
+  })
+
+  it('should create an instance when the JSON is valid and contains syncDirectories', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      syncDirectories: [{ local: 'local', remote: 'remote' }]
+    })
+
+    expect(target).toBeTruthy()
+    expect(target instanceof Target).toEqual(true)
+    expect(target.name).toEqual('test')
+    expect(target.serverUrl).toEqual('')
+    expect(target.serverType).toEqual(ServerType.Sas9)
+    expect(target.appLoc).toEqual('/test')
+    expect(target.syncDirectories).toEqual([
+      { local: 'local', remote: 'remote' }
+    ])
+  })
+
+  it('should convert an instance to JSON containing syncDirectories', () => {
+    const target = new Target({
+      name: 'test',
+      serverUrl: '',
+      serverType: ServerType.Sas9,
+      appLoc: '/test',
+      syncDirectories: [{ local: 'local', remote: 'remote' }]
+    })
+
+    const json = target.toJson()
+    expect(json).toBeTruthy()
+    expect(json.name).toEqual('test')
+    expect(json.serverUrl).toEqual('')
+    expect(json.serverType).toEqual(ServerType.Sas9)
+    expect(json.appLoc).toEqual('/test')
+    expect(json.syncDirectories).toEqual([{ local: 'local', remote: 'remote' }])
+  })
+
   it('should convert an instance to json containing build config', () => {
     const target = new Target({
       name: 'test',
@@ -448,8 +558,6 @@ describe('Target', () => {
       initProgram: '',
       termProgram: '',
       buildOutputFileName: `${target.name}.sas`,
-      buildOutputFolder: 'sasjsbuild',
-      buildResultsFolder: 'sasjsresults',
       macroVars: {}
     })
     expect(json.jobConfig).toEqual({

--- a/src/types/target.ts
+++ b/src/types/target.ts
@@ -32,7 +32,11 @@ import {
   validateAuthConfigSas9,
   validateTestConfig,
   validateSyncFolder,
-  validateSyncDirectories
+  validateSyncDirectories,
+  validateSasjsBuildFolder,
+  validateSasjsResultsFolder,
+  DEFAULT_SASJS_BUILD_FOLDER,
+  DEFAULT_SASJS_RESULTS_FOLDER
 } from './targetValidators'
 import { Configuration } from '../types/configuration'
 
@@ -59,6 +63,8 @@ export interface TargetJson {
   isDefault?: boolean
   testConfig?: TestConfig
   syncDirectories?: SyncDirectoryMap[]
+  sasjsBuildFolder?: string
+  sasjsResultsFolder?: string
 }
 
 export class Target implements TargetJson {
@@ -174,6 +180,16 @@ export class Target implements TargetJson {
   }
   private _syncDirectories: SyncDirectoryMap[] | undefined
 
+  get sasjsBuildFolder(): string | undefined {
+    return this._sasjsBuildFolder
+  }
+  private _sasjsBuildFolder: string | undefined
+
+  get sasjsResultsFolder(): string | undefined {
+    return this._sasjsResultsFolder
+  }
+  private _sasjsResultsFolder: string | undefined
+
   constructor(json: any, config: Configuration = {}) {
     try {
       if (!json) {
@@ -272,6 +288,16 @@ export class Target implements TargetJson {
       if (json.syncDirectories && json.syncDirectories.length) {
         this._syncDirectories = validateSyncDirectories(json.syncDirectories)
       }
+
+      if (json.sasjsBuildFolder) {
+        this._sasjsBuildFolder = validateSasjsBuildFolder(json.sasjsBuildFolder)
+      }
+
+      if (json.sasjsResultsFolder) {
+        this._sasjsResultsFolder = validateSasjsResultsFolder(
+          json.sasjsResultsFolder
+        )
+      }
     } catch (e) {
       throw new Error(`Error parsing target: ${(e as Error).message}`)
     }
@@ -311,6 +337,18 @@ export class Target implements TargetJson {
       json.authConfigSas9 = this.authConfigSas9
     }
 
+    if (this.sasjsBuildFolder) {
+      json.sasjsBuildFolder = this.sasjsBuildFolder
+    } else if (withDefaults) {
+      json.sasjsBuildFolder = DEFAULT_SASJS_BUILD_FOLDER
+    }
+
+    if (this.sasjsResultsFolder) {
+      json.sasjsResultsFolder = this.sasjsResultsFolder
+    } else if (withDefaults) {
+      json.sasjsResultsFolder = DEFAULT_SASJS_RESULTS_FOLDER
+    }
+
     if (this.syncDirectories) {
       json.syncDirectories = this.syncDirectories
     } else if (withDefaults) {
@@ -324,8 +362,6 @@ export class Target implements TargetJson {
         initProgram: '',
         termProgram: '',
         buildOutputFileName: `${this.name}.sas`,
-        buildOutputFolder: 'sasjsbuild',
-        buildResultsFolder: 'sasjsresults',
         macroVars: {}
       }
 

--- a/src/types/targetValidators.spec.ts
+++ b/src/types/targetValidators.spec.ts
@@ -31,7 +31,11 @@ import {
   validateTestConfig,
   validateAuthConfigSas9,
   validateSyncFolder,
-  validateSyncDirectories
+  validateSyncDirectories,
+  validateSasjsBuildFolder,
+  validateSasjsResultsFolder,
+  DEFAULT_SASJS_BUILD_FOLDER,
+  DEFAULT_SASJS_RESULTS_FOLDER
 } from './targetValidators'
 
 describe('validateTargetName', () => {
@@ -233,8 +237,6 @@ describe('validateBuildConfig', () => {
 
   it('should use the default when build output filename is undefined', () => {
     expect(validateBuildConfig({} as unknown as BuildConfig, 'test')).toEqual({
-      buildOutputFolder: 'sasjsbuild',
-      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'test.sas',
       initProgram: '',
       termProgram: '',
@@ -267,8 +269,6 @@ describe('validateBuildConfig', () => {
     expect(
       validateBuildConfig(
         {
-          buildOutputFolder: 'sasjsbuild',
-          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'output.sas',
           initProgram: 'test',
           termProgram: null
@@ -276,8 +276,6 @@ describe('validateBuildConfig', () => {
         'test'
       )
     ).toEqual({
-      buildOutputFolder: 'sasjsbuild',
-      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'output.sas',
       initProgram: 'test',
       termProgram: '',
@@ -289,8 +287,6 @@ describe('validateBuildConfig', () => {
     expect(
       validateBuildConfig(
         {
-          buildOutputFolder: 'sasjsbuild',
-          buildResultsFolder: 'sasjsresults',
           buildOutputFileName: 'output.sas',
           initProgram: 'test',
           termProgram: 'test',
@@ -299,8 +295,6 @@ describe('validateBuildConfig', () => {
         'test'
       )
     ).toEqual({
-      buildOutputFolder: 'sasjsbuild',
-      buildResultsFolder: 'sasjsresults',
       buildOutputFileName: 'output.sas',
       initProgram: 'test',
       termProgram: 'test',
@@ -1130,5 +1124,41 @@ describe('validateSyncFolder', () => {
 
   it('should return syncFolder when valid', () => {
     expect(validateSyncFolder('some/path')).toEqual('some/path')
+  })
+})
+
+describe('validateSasjsBuildFolder', () => {
+  it('should return sasjsBuildFolder', () => {
+    expect(validateSasjsBuildFolder('build')).toEqual('build')
+  })
+
+  it('should return default when provided value is blank string', () => {
+    expect(validateSasjsBuildFolder('')).toEqual(DEFAULT_SASJS_BUILD_FOLDER)
+  })
+
+  it('should throw an error when non-string value is provided', () => {
+    expect(() =>
+      validateSasjsBuildFolder(123 as unknown as string)
+    ).toThrowError(
+      `Invalid type of value (number) is provided for property 'sasjsBuildFolder' in config. Required is string.`
+    )
+  })
+})
+
+describe('validateSasjsResultsFolder', () => {
+  it('should return the provided value', () => {
+    expect(validateSasjsResultsFolder('results')).toEqual('results')
+  })
+
+  it('should return default when provided value is blank string', () => {
+    expect(validateSasjsResultsFolder('')).toEqual(DEFAULT_SASJS_RESULTS_FOLDER)
+  })
+
+  it('should throw an error when non-string value is provided', () => {
+    expect(() =>
+      validateSasjsResultsFolder(123 as unknown as string)
+    ).toThrowError(
+      `Invalid type of value (number) is provided for property 'sasjsResultsFolder' in config. Required is string.`
+    )
   })
 })

--- a/src/types/targetValidators.ts
+++ b/src/types/targetValidators.ts
@@ -17,6 +17,9 @@ const DEFAULT_CONTEXT_NAME = 'SAS Job Execution compute context'
 const DEFAULT_SERVER_NAME = 'SASApp'
 const DEFAULT_REPOSITORY_NAME = 'Foundation'
 
+export const DEFAULT_SASJS_BUILD_FOLDER = 'sasjsbuild'
+export const DEFAULT_SASJS_RESULTS_FOLDER = 'sasjsresults'
+
 export const validateServerType = (serverType: any): ServerType => {
   if (!serverType) {
     throw new Error(
@@ -193,13 +196,6 @@ export const validateBuildConfig = (
 ): BuildConfig => {
   if (!buildConfig) {
     throw new Error('Invalid build config: JSON cannot be null or undefined.')
-  }
-  if (!buildConfig.buildResultsFolder) {
-    buildConfig.buildResultsFolder = 'sasjsresults'
-  }
-
-  if (!buildConfig.buildOutputFolder) {
-    buildConfig.buildOutputFolder = 'sasjsbuild'
   }
 
   if (!buildConfig.buildOutputFileName) {
@@ -401,4 +397,28 @@ export const validateSyncDirectories = (
   })
 
   return syncDirectories
+}
+
+export const validateSasjsBuildFolder = (folderName: any) => {
+  if (typeof folderName !== 'string') {
+    throw new Error(
+      `Invalid type of value (${typeof folderName}) is provided for property 'sasjsBuildFolder' in config. Required is string.`
+    )
+  }
+
+  if (!folderName) return DEFAULT_SASJS_BUILD_FOLDER
+
+  return folderName
+}
+
+export const validateSasjsResultsFolder = (folderName: any) => {
+  if (typeof folderName !== 'string') {
+    throw new Error(
+      `Invalid type of value (${typeof folderName}) is provided for property 'sasjsResultsFolder' in config. Required is string.`
+    )
+  }
+
+  if (!folderName) return DEFAULT_SASJS_RESULTS_FOLDER
+
+  return folderName
 }


### PR DESCRIPTION
## Intent

* remove buildOutputFolder and buildResultsFolder from the build config
* add sasjsBuildFolder and sasjsResultsFolder to the top level of configuration and targetJson interfaces


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] All unit tests are passing (`npm test`).
- [ ] All `sasjs-cli` unit tests are passing (`npm test`).
- [ ] Reviewer is assigned.
