### PR TITLE
feat(compile): added validateDependency method

### DIFF
--- a/src/compileTree/compileTree.ts
+++ b/src/compileTree/compileTree.ts
@@ -1,7 +1,11 @@
 import path from 'path'
 import { createFile, readFile } from '../'
-import { getList, DependencyHeader, getDeprecatedHeader } from '../sasjsCli'
-import { newLine } from '../formatter'
+import {
+  getList,
+  DependencyHeader,
+  getDeprecatedHeader,
+  DependencyType
+} from '../sasjsCli'
 
 export interface Leaf {
   content: string
@@ -52,16 +56,52 @@ export class CompileTree {
 
   // If leaf exists, returns it's content.
   // Otherwise reads file, creates leaf and return content.
-  public async getDepContent(depPath: string) {
+  public async getDepContent(depPath: string, depType?: DependencyType) {
     const leaf = this.getLeaf(depPath)
 
     if (leaf) return leaf.content
 
+    const content = await readFile(depPath, undefined)
+
+    this.validateDependency(content, depPath, depType)
+
     return this.addLeaf({
-      content: await readFile(depPath, undefined),
+      content,
       dependencies: [],
       location: depPath
     }).content
+  }
+
+  // Throws an error if wrong dependencies have been used
+  private validateDependency(
+    content: string,
+    depPath: string,
+    depType?: DependencyType
+  ) {
+    if (!depType) return
+
+    const getErrorMessage = (
+      header: DependencyHeader,
+      dependency: DependencyType,
+      depPath: string
+    ) =>
+      `Dependency '${header}' can not be used in artefact type '${dependency}'. Please remove it from '${depPath}'.`
+
+    switch (depType) {
+      case DependencyType.Macro:
+        if (content.includes(DependencyHeader.Include)) {
+          throw new Error(
+            getErrorMessage(DependencyHeader.Include, depType, depPath)
+          )
+        } else if (content.includes(DependencyHeader.Binary)) {
+          throw new Error(
+            getErrorMessage(DependencyHeader.Binary, depType, depPath)
+          )
+        }
+
+      default:
+        break
+    }
   }
 
   // Returns file name based on file path

--- a/src/sasjsCli/getDependencies.ts
+++ b/src/sasjsCli/getDependencies.ts
@@ -104,7 +104,10 @@ export const getDependencies = async (
             Object.keys(compileTree).length &&
             depType !== DependencyType.Binary
           ) {
-            encodedFileContent = await compileTree.getDepContent(filePaths[0])
+            encodedFileContent = await compileTree.getDepContent(
+              filePaths[0],
+              depType
+            )
           } else {
             encodedFileContent = await readFile(
               filePaths[0],

--- a/src/sasjsCli/getDependencyPaths.ts
+++ b/src/sasjsCli/getDependencyPaths.ts
@@ -5,7 +5,8 @@ import {
   prioritiseDependencyOverrides,
   getList,
   DependencyHeader,
-  getDeprecatedHeader
+  getDeprecatedHeader,
+  DependencyType
 } from './'
 import { CompileTree, Leaf } from '../compileTree'
 
@@ -19,10 +20,12 @@ export async function getDependencyPaths(
   let dependencyPaths: string[] = []
   const foundDependencies: string[] = []
   const sourcePaths = [...macroFolders, macroCorePath]
+
   const dependenciesHeader = getDeprecatedHeader(
     fileContent,
     DependencyHeader.Macro
   )
+
   const dependencies =
     leaf?.dependencies ||
     getList(dependenciesHeader, fileContent).filter((d) => d.endsWith('.sas'))
@@ -38,7 +41,11 @@ export async function getDependencyPaths(
           let leaf: Leaf | undefined = undefined
 
           if (compileTree && Object.keys(compileTree).length) {
-            fileContent = await compileTree.getDepContent(filePaths[0])
+            fileContent = await compileTree.getDepContent(
+              filePaths[0],
+              DependencyType.Macro
+            )
+
             leaf = compileTree.getLeaf(filePaths[0])
           } else {
             fileContent = await readFile(filePaths[0])


### PR DESCRIPTION
## Issue

Related to https://github.com/sasjs/cli/issues/1338

## Intent

Throw an error during the compilation if `<h4> SAS Includes </h4>` or `<h4> Binary Files </h4>` headers were detected in the content of the `Macro`.

## Implementation

- Added `validateDependency` method to `CompileTree` class.
- Added unit test to cover `validateDependency`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All `sasjs-cli` unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
